### PR TITLE
Menu no mobile

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_header.sass
+++ b/source/assets/stylesheets/locastyle/modules/_header.sass
@@ -126,13 +126,10 @@ main.container
 
 	main.container
 		padding-top: 0
-<<<<<<< HEAD
 		-moz-transition: none
 		-webkit-transition: none
 		-o-transition: color 0 ease-in
 		transition: none
-=======
->>>>>>> 1073d3f4a3b4866fffb27165bcb811c32e21809c
 
 	.header
 		border-top: 4px solid #bbb

--- a/source/manual/exemplos/home.html.erb
+++ b/source/manual/exemplos/home.html.erb
@@ -17,7 +17,7 @@ layout: false
 <body>
 <header class="header" role="banner">
 	<div class="container">
-		<span class="control-menu visible-xs ico-align-justify"></span>
+		<span class="control-menu visible-xs ico-menu-2"></span>
 		<span class="control-sidebar visible-xs ico-list"></span>
 		<h1 class="project-name"><a href="#">Email Marketing</a></h1>
 		<a href="#" class="help-sugestions ico-help-circle hidden-xs">Ajuda e Sugestões</a>


### PR DESCRIPTION
Depois de muito tempo consegui fazer uma versão mais ou menos.
A ideia era que o menu ficasse com scroll interno e que o conteúdo ao
lado rolasse sem influenciar tanto no header e também no menu.
Identifiquei um ou outro erro de comportamento, mas que eu não vejo
soluções ainda.

Agora tem que fazer a sidebar. Ela tem um comportamento diferente: em
vez de empurrar o conteúdo todo, ela só sobrepoe. Parece ser mais fácil.
