### PR TITLE
Melhoria

### DIFF
--- a/source/assets/stylesheets/locastyle/_sidebar.css
+++ b/source/assets/stylesheets/locastyle/_sidebar.css
@@ -220,3 +220,4 @@ h5 + .innerSideBox {margin-top:5px;}
 .innerSideBox small{font-size: 11px; line-height: 1.1em; }
 .sidebar .progress{margin: 0;}
 .progressInfo{font-size: 11px; }
+.sideBox p.ellipsis{width: 100%;}


### PR DESCRIPTION
Caso exista textos longos sem espacamentos, basta inserir a classe funcional ellipsis que evita quebra de layout
