### PR TITLE
Removendo link Collapse de aplicações

### DIFF
--- a/source/partials/_sidebar-aplicacoes.erb
+++ b/source/partials/_sidebar-aplicacoes.erb
@@ -4,7 +4,6 @@
 	<ul>
 		<!-- <li><%= link_to "Busca avançada", "#{base_url}/manual/aplicacoes/busca-avancada" %></li> -->
 		<!-- <li><%= link_to "Chamada vários links", "#{base_url}/manual/aplicacoes/chamada-varios-links" %></li> -->
-		<li><%= link_to "Collapse", "#{base_url}/manual/aplicacoes/collapse" %></li>
 		<li><%= link_to "Filtro exibição e paginação", "#{base_url}/manual/aplicacoes/paginacao" %></li>
 		<li><%= link_to "Lista", "#{base_url}/manual/aplicacoes/lista" %></li>
 	</ul>


### PR DESCRIPTION
O link Collapse agora está em Componentes
