### PR TITLE
Removendo comentários do arquivo

### DIFF
--- a/source/manual/estilo/javascript.html.erb
+++ b/source/manual/estilo/javascript.html.erb
@@ -72,68 +72,6 @@ if ( x < 0 ) {
       Observe os alinhamentos, quebras de linhas, posição das chaves e espaços entre variáveis e operadores.
     </small>
   </p>
-
-  <!--
-    'use strict';
-    escolha de plugins
-    internacionalizaçao (plugin/semplugin/gem)
-    nomenclatura de arquivos
-    Código em apenas um idioma
-    separaçao mvc
-    aspas simples em evz de duplas
-    declaraçao de variaveis no inicio
-    final de linahs vazias (editorconfig)
-    nomenclatura
-    this / _self / bind / apply / call / $name
-    switch nao
-    sem medo de ifs aninhados
-    Retornos antecipados
-    retornos apenas com utilidade
-    chaining
-     código deve ficar em arquivos externos.
-     sem user-agent
-     sem document.write()
-     variáveis boleanas  + isName
-     docs http://www.naturaldocs.org/documenting.html
-     Constantes ou variáveis de configuração no inicio
-     patterns alternativos  Object Literal/Singleton, Object constructors.
-     marcação discreta abrangente baseada em DOM
-     variaveis camelCase
-     Delegação de Eventos
-      eventos corretos
-    delegate x on x live
-    (Not) Augmenting Built-in Prototypes
-    sem  Conversão de Tipo Implícita
-    sem eval()
-     parseInt() com tipo
-     Capitalize Constructors
-     sem with continue Statement
-     cuidado com Bitwise
-
-    Notações literais:
-      var array = [],
-        object = {};
-
-    apenas um `var` por escopo
-    var foo = "",
-      bar = "",
-      quux;
-
-    // Expressão de função
-    var square = function( number ) {
-      // Retorna algo de valor e relevante
-      return number * number;
-    };
-
-    closures
-
-    refs
-      idiomatic.js
-      http://contribute.jquery.org/style-guide/js/
-      http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
-      https://github.com/es-analysis/plato
-   -->
-
    <h3>
      Revealing Module Pattern
    </h3>


### PR DESCRIPTION
Não precisamos manter esta lista como comentário no arquivo.

Tanure, da lista, acho que precisamos fazer estes:
- 'use strict';
- nomenclatura de arquivos
- Código em apenas um idioma
- variaveis camelCase
- Delegação de Eventos (eventos corretos)
- delegate x on x live
