### PR TITLE
grandiente linear absoluto em vez de percentual

### DIFF
--- a/source/assets/stylesheets/locastyle/_base.css
+++ b/source/assets/stylesheets/locastyle/_base.css
@@ -10,12 +10,8 @@ html, body {
   min-height: 75%;
   position: relative;
   background-color: #FFF;
-  background: -moz-linear-gradient(top,  rgba(232,232,232,1) 0%, rgba(252,252,252,1) 3%, rgba(255,255,255,1) 7%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(232,232,232,1)), color-stop(3%,rgba(252,252,252,1)), color-stop(7%,rgba(255,255,255,1)));
-  background: -webkit-linear-gradient(top,  rgba(232,232,232,1) 0%,rgba(252,252,252,1) 3%,rgba(255,255,255,1) 7%);
-  background: -o-linear-gradient(top,  rgba(232,232,232,1) 0%,rgba(252,252,252,1) 3%,rgba(255,255,255,1) 7%);
-  background: -ms-linear-gradient(top,  rgba(232,232,232,1) 0%,rgba(252,252,252,1) 3%,rgba(255,255,255,1) 7%);
-  background: linear-gradient(to bottom,  rgba(232,232,232,1) 0%,rgba(252,252,252,1) 3%,rgba(255,255,255,1) 7%);
+  background: -ms-linear-gradient( top,       rgba(232,232,232,1) 0,rgba(252,252,252,1) 30px,rgba(255,255,255,1) 60px);
+  background: linear-gradient(     to bottom, rgba(232,232,232,1) 0,rgba(252,252,252,1) 30px,rgba(255,255,255,1) 60px);
 }
 
 #main > .limit {padding-bottom: 160px;}


### PR DESCRIPTION
removi também os vendor prefixes de browsers modernos. todos já suportam a sintaxe padrão
