### PR TITLE
Track events verifica se o ga está presente antes de rodar os finders

### DIFF
--- a/source/assets/javascripts/locastyle/_track_events.js
+++ b/source/assets/javascripts/locastyle/_track_events.js
@@ -4,6 +4,15 @@ locastyle.trackEvents = (function() {
   'use strict';
 
   function init(){
+    if(window.ga){
+      findTriggers();
+      this.gaPresent = true;
+    } else {
+      this.gaPresent = false;
+    }
+  }
+
+  function findTriggers(){
     findLinks();
     findButtons();
     findForms();

--- a/spec/javascripts/track_events_spec.js
+++ b/spec/javascripts/track_events_spec.js
@@ -6,6 +6,20 @@ describe("Track Events", function() {
     locastyle.trackEvents.init();
   });
 
+  describe("Initialization", function () {
+    describe("Check ga presence before init finding functions", function () {
+      it("should call findTriggers if window.ga is present", function () {
+        expect(locastyle.trackEvents.gaPresent).toEqual(true);
+      });
+
+      it("should not call findTriggers if window.ga is NOT present", function () {
+        window.ga = null;
+        locastyle.trackEvents.init();
+        expect(locastyle.trackEvents.gaPresent).toEqual(false);
+      });
+    });
+  });
+
   describe("Common links", function () {
     describe("When click on a link on #home_menu_sample", function () {
       it("should call ga with ('send', 'event', 'locastyle#track-events-test', 'open_link_#/home', 'Open link sample') arguments", function () {


### PR DESCRIPTION
A implementação está estranha por conta do gaPresent, mas foi o que consegui para deixar testado.

Tentei testar este negócio o dia todo, tentei com o spyOn do jasmine, não deu certo, instalei o sinon.js para usar os spies do sinon porque achei que o restore do spy ia me ajudar, mas também sem sucesso.

Então é isso, se alguém conseguir testar se o findTriggers() está sendo chamado ou não, quando o ga está presente ou não, por favor o faça.
