### PR TITLE
Removing active_support/core_ext require from config

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -78,7 +78,6 @@ set :images_dir, 'assets/images'
 activate :directory_indexes
 activate :i18n
 
-require 'active_support/core_ext'
 activate :blog do |blog|
     blog.prefix = "changelog"
     blog.permalink = ":year/:month/:day/:title"


### PR DESCRIPTION
We don't need it there.
