### PR TITLE
added rack-cros gem to added Access-Control-Allow-Origin header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,5 @@ gem "pry"
 
 gem 'middleman-gh-pages'
 gem "middleman-syntax"
+
+gem 'rack-cors', require: false

--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,12 @@
+require 'rack/cors'
+use Rack::Cors do
+  allow do
+    origins '*'
+    resource '*', headers: :any, methods: :get
+  end
+end
+
+
 ###
 # Compass
 ###


### PR DESCRIPTION
I think that is a good point to help you to develop others projects with midleman default server from other host.

Ex
start middleman at port 4567
start otherprojet at port 3000 using the locawebstyle at 4567
