### PR TITLE
little fixes to 3.2.0

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_alerts.sass
+++ b/source/assets/stylesheets/locastyle/modules/_alerts.sass
@@ -8,6 +8,7 @@
 
   p
     color: inherit
+    margin-bottom: 0
 
   a:not([class*="ls-btn"])
     color: inherit


### PR DESCRIPTION
[x] Removing text-decoration of links in ls-alerts. the LS already put a bor...der-bottom to make underline.
[x] Removing margin-bottom of paragraph in ls-alerts.

close https://github.com/locaweb/locawebstyle/issues/1065
close https://github.com/locaweb/locawebstyle/issues/1067
