### PR TITLE
Capitalize only the first word on form labels. 

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -23,8 +23,8 @@
   margin-bottom: 15px
   @extend .ls-clearfix
 
-  .ls-label-text
-    text-transform: capitalize
+  .ls-label-text:first-letter
+    text-transform: uppercase
 
   b,
   label


### PR DESCRIPTION
- Fix issue #1249
