### PR TITLE
Removing capitalize of labels in forms.

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -23,9 +23,6 @@
   margin-bottom: 15px
   @extend .ls-clearfix
 
-  .ls-label-text
-    text-transform: capitalize
-
   b,
   label
     display: block


### PR DESCRIPTION
I am removing this CSS because we should talk about this @diegoeis 
