### PR TITLE
Resolving issue #1264

### DIFF
--- a/source/assets/javascripts/locastyle/_general.js
+++ b/source/assets/javascripts/locastyle/_general.js
@@ -42,7 +42,7 @@ locastyle.general = (function() {
   function _autoTrigger(){
     var hash = window.location.hash.replace("!/#", "");
     if(hash !== ''){
-      $('[data-target=' + hash + '], a[href=' + hash + ']').trigger('click');
+      $('[data-target="' + hash + '"], a[href="' + hash + '"]').trigger('click');
     }
   }
 


### PR DESCRIPTION
@nyubai, @renatocn I solve this syntax error here just inserting double quotation in complex attribute selector. I think this solve this issue. Can you test? I think you need to download the Locaweb Style of my personal branch 'wip'. 

Browsers understand this attribute selector without double quotation, but is a good practice always use double quotations this selectors.
