### PR TITLE
fixing wrong indentation of property in ls-topbar

### DIFF
--- a/source/assets/stylesheets/docs/_base.sass
+++ b/source/assets/stylesheets/docs/_base.sass
@@ -693,7 +693,7 @@ p code
     overflow: hidden
 
     .ls-topbar:after
-    content: none
+        content: none
 
 
   .ls-topbar


### PR DESCRIPTION
This close #1331