### PR TITLE
Fast Init

### DIFF
--- a/source/assets/javascripts/locastyle/_initializer.js
+++ b/source/assets/javascripts/locastyle/_initializer.js
@@ -1,10 +1,12 @@
 var locastyle = (function() {
   'use strict';
 
+  // Used to run scripts when the HTML is ready
   function fastInit() {
     locastyle.sidebarToggle.init();
   }
 
+  // Used to run scripts that just when all things are ready
   function init() {
     locastyle.breakpoints.init();
     loadModules();

--- a/source/assets/javascripts/locastyle/_initializer.js
+++ b/source/assets/javascripts/locastyle/_initializer.js
@@ -1,12 +1,15 @@
 var locastyle = (function() {
   'use strict';
 
+  function fastInit() {
+    locastyle.sidebarToggle.init();
+  }
+
   function init() {
     locastyle.breakpoints.init();
     loadModules();
     locastyle.general.init();
     locastyle.sidebars.init();
-    locastyle.sidebarToggle.init();
     locastyle.btnGroup.init();
     locastyle.alert.init();
     locastyle.datepicker.init();
@@ -41,7 +44,8 @@ var locastyle = (function() {
   }
 
   return {
-    init: init
+    init: init,
+    fastInit: fastInit
   };
 
 }());
@@ -50,4 +54,8 @@ var ls = locastyle;
 
 $(window).load(function() {
   locastyle.init();
+});
+
+$(document).ready(function(){
+  locastyle.fastInit();
 });


### PR DESCRIPTION
We made this method to start functions faster. Some functions work
better when the document is ready. Using in this way, we don’t need to
wait the window load.