### PR TITLE
Fixing the size of documetation paragraphs. The Locastyle was importing ...

### DIFF
--- a/source/assets/stylesheets/locastyle/base/_typography.sass
+++ b/source/assets/stylesheets/locastyle/base/_typography.sass
@@ -39,8 +39,7 @@ body
   font-weight: bold
 
 p, li
-  @extend .ls-text-default
-  font-size: remtopx(.875)
+  font-size: remtopx(.8125)
   letter-spacing: .2px
 
 p


### PR DESCRIPTION
...the class .ls-text-default. This class is a helper-class and usually all helper classes have important defined. So, I removed this include to solve the problem.