### PR TITLE
bug fix in the navigation component of step

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_steps.sass
+++ b/source/assets/stylesheets/locastyle/modules/_steps.sass
@@ -121,7 +121,8 @@ $with-steps: 85px
   height: 0
   width: 0
   position: absolute
-  top: 6px
+  top: 50%
+  margin-top: -23px
   right: 18px
 
   &:before,

--- a/source/assets/stylesheets/locastyle/modules/_steps.sass
+++ b/source/assets/stylesheets/locastyle/modules/_steps.sass
@@ -55,10 +55,8 @@ $with-steps: 85px
   font-weight: 300
   color: $gray2
   padding-right: 5px
-  padding-top: 1px
   pointer-events: none
   position: relative
-  z-index: 2
 
   .ls-active &,
   .ls-actived &
@@ -106,6 +104,8 @@ $with-steps: 85px
     vertical-align: middle
     text-align: center
     width: 35px
+    position: relative
+    z-index: 2
 
   &:after
     content: attr(aria-label)
@@ -200,3 +200,7 @@ $with-steps: 85px
       position: relative
       top: 0
       margin-left: 10px
+      width: 170px
+      text-align: left
+      display: inline-block
+      vertical-align: middle


### PR DESCRIPTION
Fix related issue #1434 

*Note: Correction tested in all browsers that support Locastyle*

**Now the component navigation with large texts are as print below**
![fix-step](https://cloud.githubusercontent.com/assets/1235904/6874686/1b20d3c0-d498-11e4-9000-b4ea5172ef1b.jpg)
