### PR TITLE
Fix char counter with substring

### DIFF
--- a/source/assets/javascripts/locastyle/_char-counter.js
+++ b/source/assets/javascripts/locastyle/_char-counter.js
@@ -9,17 +9,22 @@ locastyle.charCounter = (function() {
 
   function countText(){
     $('[data-ls-module="charCounter"]').each(function(index, field){
-      var fieldText = $(field).val().length;
       var limit = $(field).attr('maxlength');
+      $(field).removeAttr('maxlength').data().maxlength = limit;
       $(field).after('<p class="ls-help-inline"><small><strong class="ls-char-count ls-number-counter-'+index+'">'+limit+'</strong> caracteres restantes</small></p>');
 
-      var calc = limit-fieldText;
-      updateCounter(index, calc);
-
       $(field).keyup(function(){
-        var count = limit - $(this).val().length;
-        updateCounter(index, count);
+        var count = $(this).val().length;
+        var limit = $(this).data().maxlength;
+
+        if(count > limit) {
+          $(this).val($(this).val().substring(0, limit));
+        } else {
+          updateCounter(index, limit - count);
+        }
       });
+
+      $(field).trigger('keyup');
     });
   }
 

--- a/spec/javascripts/counter_spec.js
+++ b/spec/javascripts/counter_spec.js
@@ -19,5 +19,4 @@ describe("Counter char: ", function(){
 
   });
 
-
 });


### PR DESCRIPTION
This problem have on moment with input or textarea using attr maxlength.

On javascript remove attr maxlength on textearea/input and add treatments internal char count.

If count large text more than maxlength defined, cut with substring of 0 for max.