### PR TITLE
Bug fix to prefix and sufix when inline form

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -276,11 +276,6 @@ input.ls-form-text,
   display: table
 
   .ls-form-inline &
-    float: none
-    display: inline-block
-    width: 200px
-    vertical-align: middle
-    height: 38px
 
     input + .ls-label-text-prefix
       height: inherit

--- a/source/documentacao/formularios/exibir-senha.html.erb
+++ b/source/documentacao/formularios/exibir-senha.html.erb
@@ -16,4 +16,11 @@ type: forms
   </div>
   <% code("html") do %><%= partial 'documentacao/shared/password' %><% end %>
 
+
+  <p>Pra mudar o layout basta adicionar no form a classe <code>.ls-form-inline</code></p>
+  <div class="ls-box-demo">
+    <%= partial 'documentacao/shared/password-inline' %>
+  </div>
+  <% code("html") do %><%= partial 'documentacao/shared/password-inline' %><% end %>
+
 </section>

--- a/source/documentacao/formularios/prefixos-sufixos.html.erb
+++ b/source/documentacao/formularios/prefixos-sufixos.html.erb
@@ -14,4 +14,12 @@ description: Personalização com adendos para os campos
     <%= partial 'documentacao/shared/form/fields-prefix-sufix.erb' %>
   </div>
   <% code("html") do %><%= partial 'documentacao/shared/form/fields-prefix-sufix.erb' %><% end %>
+
+
+
+  <p>Pra mudar o layout basta adicionar no form a classe <code>.ls-form-inline</code></p>
+  <div class="ls-box-demo">
+    <%= partial 'documentacao/shared/form/fields-prefix-sufix-inline.erb' %>
+  </div>
+  <% code("html") do %><%= partial 'documentacao/shared/form/fields-prefix-sufix-inline.erb' %><% end %>
 </section>

--- a/source/documentacao/shared/_password-inline.erb
+++ b/source/documentacao/shared/_password-inline.erb
@@ -1,0 +1,21 @@
+<form action="" class="ls-form ls-form-inline row">
+  <fieldset>
+    <label class="ls-label col-md-6">
+      <b class="ls-label-text">Senha (com ícone)</b>
+      <div class="ls-prefix-group">
+        <input type="password" maxlength="20" id="password_field2a" name="password" value="locastyle é da hora né?" >
+          <a class="ls-label-text-prefix ls-toggle-pass ls-ico-eye" data-toggle-class="ls-ico-eye, ls-ico-eye-blocked" data-target="#password_field2a" href="#">
+          </a>
+      </div>
+    </label>
+  </fieldset>
+</form>
+<form action="" class="ls-form ls-form-inline">
+  <fieldset>
+    <label class="ls-label">
+      <b class="ls-label-text ls-hidden-accessible">Senha (com texto)</b>
+      <input type="password" maxlength="20" id="password_field3a" name="password" value="locastyle é da hora né?" >
+      <a class="ls-toggle-pass ls-color-theme" data-target="#password_field3a" href="#">Alterar</a>
+    </label>
+  </fieldset>
+</form>

--- a/source/documentacao/shared/_password.erb
+++ b/source/documentacao/shared/_password.erb
@@ -1,4 +1,4 @@
-<form action="" class="ls-form ls-form-horizontal row">
+<form action="" class="ls-form row">
   <fieldset>
     <label class="ls-label col-md-4">
       <b class="ls-label-text">Senha (com ícone)</b>

--- a/source/documentacao/shared/form/_fields-prefix-sufix-inline.erb
+++ b/source/documentacao/shared/form/_fields-prefix-sufix-inline.erb
@@ -1,4 +1,4 @@
-<form action="" class="ls-form row">
+<form action="" class="ls-form ls-form-inline row">
 
   <label class="ls-label col-md-8">
     <b class="ls-label-text">Escreva o endereço do seu site</b>
@@ -9,7 +9,7 @@
     </div>
   </label>
 
-  <label class="ls-label col-md-8">
+  <label class="ls-label col-md-10 col-sm-10">
     <b class="ls-label-text">Escreva o endereço do seu site</b>
 
     <div class="ls-prefix-group">


### PR DESCRIPTION
Resolve issue #1352

- [x] **Fix sample prefix and sufix, when inline form**
![prefixsufix-inline](https://cloud.githubusercontent.com/assets/1235904/7162081/f64350ca-e368-11e4-9957-3a64b8906117.jpg)

- [x] **Fix element display password, when inline form**
![password-inline](https://cloud.githubusercontent.com/assets/1235904/7162086/02a3ca5c-e369-11e4-82ee-027a07ad8f0b.jpg)


