### PR TITLE
fix collapse when header text is very large

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_collapse.sass
+++ b/source/assets/stylesheets/locastyle/modules/_collapse.sass
@@ -28,7 +28,7 @@
 
 .ls-collapse-header
   display: block
-  padding: 10px
+  padding: 10px 35px 10px 10px
   cursor: pointer
   position: relative
 

--- a/source/assets/stylesheets/locastyle/modules/_collapse.sass
+++ b/source/assets/stylesheets/locastyle/modules/_collapse.sass
@@ -31,6 +31,7 @@
   padding: 10px 35px 10px 10px
   cursor: pointer
   position: relative
+  word-wrap: break-word
 
   &:before
     +rotate(0deg)


### PR DESCRIPTION
Resolve issue #1461 

![print-collapse](https://cloud.githubusercontent.com/assets/1235904/7354101/236af64a-ecef-11e4-84b5-af654ea07858.png)
