### PR TITLE
Move menu link to another page.

### DIFF
--- a/source/documentacao/introducao/estrutura-principal.html.erb
+++ b/source/documentacao/introducao/estrutura-principal.html.erb
@@ -1,10 +1,9 @@
 ---
 title: Estrutura principal
 description: É daqui que você vai começar. Nosso Boilerplate responsivo tem header, menu lateral e uma estrutura de conteúdo principal que é fluida, ou seja, sem largura limitada.
-type: component
 ---
 
-<%= partial 'partials/doc-menu-components'%>
+<%= partial 'partials/doc-menu-intro'%>
 
 <section class="col-md-9">
 

--- a/source/partials/_doc-menu-components.html.erb
+++ b/source/partials/_doc-menu-components.html.erb
@@ -2,7 +2,6 @@
 <div class="doc-sidebar-inner doc-sidebar-componentes">
   <nav class="doc-sidebar-menu">
     <ul>
-      <%= menu_tag("/documentacao/componentes/estrutura-principal/", "Estrutura principal") %>
       <%= menu_tag("/documentacao/componentes/", "Abas") %>
       <%= menu_tag("/documentacao/componentes/alertas/", "Alertas") %>
       <%= menu_tag("/documentacao/componentes/barra-de-progresso/", "Barra de Progresso") %>

--- a/source/partials/_doc-menu-intro.html.erb
+++ b/source/partials/_doc-menu-intro.html.erb
@@ -3,6 +3,7 @@
   <nav class="doc-sidebar-menu">
     <ul>
       <%= menu_tag("/documentacao/introducao/", "Informações iniciais")%>
+      <%= menu_tag("/documentacao/introducao/estrutura-principal/", "Estrutura principal") %>
       <%= menu_tag("/documentacao/introducao/boilerplate/", "Comece por aqui")%>
       <%= menu_tag("/documentacao/praticas/css/", "Padrões de CSS")%>
       <%= menu_tag("/documentacao/praticas/javascript/", "Padrões de Javascript")%>

--- a/source/partials/_doc-menu-top.html.erb
+++ b/source/partials/_doc-menu-top.html.erb
@@ -4,7 +4,7 @@
       <%= menu_tag("/documentacao/introducao/", "Introdução")%>
       <%= menu_tag("/documentacao/css/grid/", "CSS")%>
       <%= menu_tag("/documentacao/funcoes-js/", "Funções JS")%>
-      <%= menu_tag("/documentacao/componentes/estrutura-principal/", "Componentes")%>
+      <%= menu_tag("/documentacao/componentes/", "Componentes")%>
       <%= menu_tag("/documentacao/formularios/", "Formulários")%>
       <%= menu_tag("/documentacao/exemplos/", "Telas de Exemplo")%>
       <%= menu_tag("/documentacao/cartilha-de-elementos/", "Cartilha de Elementos")%>


### PR DESCRIPTION
Link to 'Estrutura principal' moved to 'Introdução' page.
It makes more sense.