### PR TITLE
Add 2 events when change the step

### DIFF
--- a/source/assets/javascripts/locastyle/_steps.js
+++ b/source/assets/javascripts/locastyle/_steps.js
@@ -113,21 +113,33 @@ locastyle.steps = (function() {
 
   // Advances to the next step
   function nextStep() {
+    // TODO: when change the minor version we can remove this old event.
     var evt = jQuery.Event('NextStepEvent');
     $(document).trigger(evt);
-    if(!evt.isDefaultPrevented()) {
+
+    var beforeEvent = jQuery.Event('BeforeNextStep');
+    $(document).trigger(beforeEvent);
+
+    if(!evt.isDefaultPrevented() && !beforeEvent.isDefaultPrevented()) {
       var $el = $(config.selectors.nav).find(config.classes.active).next('li').addClass(config.status.active).find(config.selectors.button);
       changeStep($el);
+      $(document).trigger(jQuery.Event('AfterNextStep'));
     }
   }
 
   // Back to the previous step
   function prevStep() {
+    // TODO: when change the minor version we can remove this old event.
     var evt = jQuery.Event('PrevStepEvent');
     $(document).trigger(evt);
-    if(!evt.isDefaultPrevented()) {
+
+    var beforeEvent = jQuery.Event('BeforePrevStep');
+    $(document).trigger(beforeEvent);
+
+    if(!evt.isDefaultPrevented() && !beforeEvent.isDefaultPrevented()) {
       var $el = $(config.selectors.nav).find(config.classes.active).prev('li').find(config.selectors.button);
       changeStep($el);
+      $(document).trigger(jQuery.Event('AfterPrevStep'));
     }
   }
 

--- a/spec/javascripts/steps_spec.js
+++ b/spec/javascripts/steps_spec.js
@@ -89,6 +89,27 @@ describe("Steps: ", function(){
       });
     });
 
+    describe('when BeforeNextStep is prevented', function(){
+      it('does not change to next step', function(){
+        $(document).on('BeforeNextStep', function(e){ e.preventDefault(); });
+        locastyle.steps.nextStep();
+        expect($('#list3').hasClass('ls-active')).toBe(false);
+        $(document).off('BeforeNextStep');
+      });
+    });
+
+    describe('AfterNextStep', function(){
+      it('triggers this event after change the step', function(){
+        var activeStepId = 'lala';
+        $(document).on('AfterNextStep', function(){
+          activeStepId = $('.ls-steps-content.ls-active').attr('id');
+        });
+        locastyle.steps.nextStep();
+        expect(activeStepId).toEqual('step3');
+        $(document).off('AfterNextStep');
+      });
+    });
+
     describe('bind button', function(){
       it('when click change to next step', function(){
         $('#next2').trigger('click');
@@ -109,6 +130,27 @@ describe("Steps: ", function(){
         locastyle.steps.prevStep();
         expect($('#list1').hasClass('ls-active')).toBe(false);
         $(document).off('PrevStepEvent');
+      });
+    });
+
+    describe('when BeforePrevStep is prevented', function(){
+      it('does not change to prev step', function(){
+        $(document).on('BeforePrevStep', function(e){ e.preventDefault(); });
+        locastyle.steps.prevStep();
+        expect($('#list1').hasClass('ls-active')).toBe(false);
+        $(document).off('BeforePrevStep');
+      });
+    });
+
+    describe('AfterPrevStep', function(){
+      it('triggers this event after change the step', function(){
+        var activeStepId = 'lala';
+        $(document).on('AfterPrevStep', function(){
+          activeStepId = $('.ls-steps-content.ls-active').attr('id');
+        });
+        locastyle.steps.prevStep();
+        expect(activeStepId).toEqual('step1');
+        $(document).off('AfterPrevStep');
       });
     });
 


### PR DESCRIPTION
Tigger new events to before and after each changes.

With this way we can attach some function after the new step is active like put focus to an input on the step that is active.

I don't remove the old event because it's can break compatibility. So I just add a TODO to remove it when you change the minor or major version.

WDYT? 