### PR TITLE
Fix collapse when have .ls-collapse-opened-always.

### DIFF
--- a/source/assets/javascripts/locastyle/_collapse.js
+++ b/source/assets/javascripts/locastyle/_collapse.js
@@ -45,7 +45,7 @@ locastyle.collapse = (function() {
         $(config.classes.content).on('click.ck', function(event) {
           event.stopPropagation();
         });
-      };
+      }
     });
   }
 

--- a/source/assets/javascripts/locastyle/_collapse.js
+++ b/source/assets/javascripts/locastyle/_collapse.js
@@ -31,20 +31,22 @@ locastyle.collapse = (function() {
   }
 
   function bind() {
-    if (!$(config.trigger).hasClass(config.classes.alwaysOpened)) {
-      $(config.trigger).on('click.ls', function() {
-        groupCollapse($(this));
-        // get target
-        var target = $(this).data('target');
-        toggle(target);
-        // set aria's attributes
-        ariaCollapse($(this));
-      });
-      // if click on ls-collapse-body no action happens
-      $(config.classes.content).on('click.ls', function(event) {
-        event.stopPropagation();
-      });
-    }
+    $(config.trigger).each(function(index, element) {
+      if (!$(element).hasClass(config.classes.alwaysOpened)) {
+        $(element).on('click.ck', function() {
+          groupCollapse($(this));
+          // get target
+          var target = $(this).data('target');
+          toggle(target);
+          // set aria's attributes
+          ariaCollapse($(this));
+        });
+        // if click on ck-collapse-body no action happens
+        $(config.classes.content).on('click.ck', function(event) {
+          event.stopPropagation();
+        });
+      };
+    });
   }
 
   // if have collapses in group "accordeon"

--- a/source/documentacao/shared/collapse/_collapse.erb
+++ b/source/documentacao/shared/collapse/_collapse.erb
@@ -1,5 +1,5 @@
 <% quant.times do |num| %>
-  <div data-ls-module="collapse" data-target="#<%= id %><%= num %>" class="ls-collapse<% if defined?(startOpen) %> ls-collapse-open <% end %> <% if defined?(alwaysOpen) %> ls-collapse-open-always <% end %>">
+  <div data-ls-module="collapse" data-target="#<%= id %><%= num %>" class="ls-collapse<% if defined?(startOpen) %> ls-collapse-open <% end %> <% if defined?(alwaysOpen) %> ls-collapse-opened-always <% end %>">
     <a href="#" class="ls-collapse-header">
       <% if header.is_a? String %>
       <h3 class="ls-collapse-title"><%= header %> <%= num+1 %></h3>


### PR DESCRIPTION
When any collapse has .ls-collapse-always-opened class, all collapses in the page lose functionality.
This is now fixed.