### PR TITLE
Tab event. Close #1488

### DIFF
--- a/source/assets/javascripts/locastyle/_tabs.js
+++ b/source/assets/javascripts/locastyle/_tabs.js
@@ -28,6 +28,9 @@ locastyle.tabs = (function() {
       if(isDropdownMode($(this).parents('.ls-tabs-nav'))){
         updateTriggerLink($(this).parents('.ls-tabs-nav'));
       }
+
+      // This event return two arguments: element clicked and content target.
+      $.event.trigger('tab:clicked', [$(this), $target]);
     });
   }
 

--- a/source/assets/javascripts/locastyle/_tabs.js
+++ b/source/assets/javascripts/locastyle/_tabs.js
@@ -20,20 +20,20 @@ locastyle.tabs = (function() {
 
   // bind click and call the necessary methods
   function bindClickOnTriggers() {
-    $("[data-ls-module=tabs]").on("click.ls", function(evt) {
+    $('[data-ls-module="tabs"]').on('click.ls', function(evt) {
       evt.preventDefault();
-      var $target = $($(this).attr("href") || $(this).data("target"));
+      var $target = $($(this).attr('href') || $(this).data('target'));
       deactivateTab(this, $target);
       activateTab(this, $target);
-      if(isDropdownMode($(this).parents(".ls-tabs-nav"))){
-        updateTriggerLink($(this).parents(".ls-tabs-nav"));
+      if(isDropdownMode($(this).parents('.ls-tabs-nav'))){
+        updateTriggerLink($(this).parents('.ls-tabs-nav'));
       }
     });
   }
 
   // bind the breakpoint-updated event calls the checker when fired
   function bindBreakpointUpdateOnChecker() {
-    $(window).on("breakpoint-updated", function () {
+    $(window).on('breakpoint-updated', function () {
       locastyle.tabs.checkBreakpoint();
     });
   }
@@ -45,8 +45,8 @@ locastyle.tabs = (function() {
 
   // check the breakpoint and if the tab is already in droppdown mode
   function checkBreakpoint() {
-    if(locastyle.breakpointClass === "ls-window-sm" || locastyle.breakpointClass === "ls-window-xs"){
-      $(".ls-tabs-nav").each(function (index, value) {
+    if(locastyle.breakpointClass === 'ls-window-sm' || locastyle.breakpointClass === 'ls-window-xs'){
+      $('.ls-tabs-nav').each(function (index, value) {
         if(!isDropdownMode(value)){
           dropdownShape(value);
         }
@@ -57,13 +57,13 @@ locastyle.tabs = (function() {
   // update dropdown link with value of active tab
   function updateTriggerLink(tabNav) {
     // clean the current trigger
-    $(tabNav).parents(".ls-dropdown-tabs").find("> a").remove();
+    $(tabNav).parents('.ls-dropdown-tabs').find('> a').remove();
 
     // update with the new trigger
-    $(tabNav).parents(".ls-dropdown-tabs").prepend($(tabNav).find("li.ls-active").html());
+    $(tabNav).parents('.ls-dropdown-tabs').prepend($(tabNav).find('li.ls-active').html());
 
     // add style class on trigger
-    $(tabNav).parents(".ls-dropdown-tabs").find("> a").addClass("ls-btn");
+    $(tabNav).parents('.ls-dropdown-tabs').find('> a').addClass('ls-btn');
 
     // resets the dropdown module to catch the new trigger
     locastyle.dropdown.init();
@@ -78,29 +78,29 @@ locastyle.tabs = (function() {
     updateTriggerLink(tabNav);
 
     // adds class amending style links
-    $(tabNav).addClass("in-dropdown");
+    $(tabNav).addClass('in-dropdown');
 
     // adds class used by dropdown to the toggle
-    $(tabNav).addClass("ls-dropdown-nav");
+    $(tabNav).addClass('ls-dropdown-nav');
   }
 
   // activates the flap in accordance with the received arguments
   function activateTab(el, $target) {
-    $(el).parents("li").addClass("ls-active");
-    $target.addClass("ls-active");
+    $(el).parents('li').addClass('ls-active');
+    $target.addClass('ls-active');
     $(el).attr('aria-selected' , true);
   }
 
   // disable tab according to the received arguments
   function deactivateTab(el, $target) {
-    $(el).parents("li").siblings().removeClass("ls-active");
-    $target.siblings().removeClass("ls-active");
-    $(el).parents("li").siblings().find('a').attr('aria-selected' , false);
+    $(el).parents('li').siblings().removeClass('ls-active');
+    $target.siblings().removeClass('ls-active');
+    $(el).parents('li').siblings().find('a').attr('aria-selected' , false);
   }
 
   // remove binds added by the module itself
   function unbind() {
-    $("[data-ls-module=tabs]").off("click.ls");
+    $('[data-ls-module=tabs]').off('click.ls');
   }
 
   function ariaTabs() {

--- a/source/documentacao/componentes/index.html.erb
+++ b/source/documentacao/componentes/index.html.erb
@@ -94,4 +94,30 @@ type: component
     <%= partial 'documentacao/shared/abas-dropdown-nav' %>
   </div>
   <% code("html") do %><%= partial 'documentacao/shared/abas-dropdown-nav' %><% end %>
+
+  <h2 class="doc-title-3">Eventos</h2>
+  <table class="ls-table">
+    <thead>
+      <tr>
+        <th width="200">Evento</th>
+        <th>Descrição</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>tab:clicked</th>
+        <td><p>Quando uma aba é clicada, o evento <code>tab:clicked</code> é disparado com dois argumentos: o primeiro argumento é o elemento que foi clicado. O segundo argumento é o target do conteúdo relacionado aquela aba.</p></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>Exemplo: </p>
+  <% code("javascript") do %>
+function someFunction() {
+  $(document).on('tab:clicked', function(evt, arg1, arg2){
+    console.log(arg1, arg2);
+  })
+}
+  <%end%>
+
 </section>

--- a/spec/javascripts/tabs_spec.js
+++ b/spec/javascripts/tabs_spec.js
@@ -23,6 +23,12 @@ describe("Tabs: ", function() {
         expect(spyEvent).toHaveBeenPrevented();
       });
 
+      it("should triggered the event tab:clicked", function() {
+        var spyEvent = spyOnEvent(document, 'tab:clicked');
+        $("#tab-trigger-2").trigger("click");
+        expect(spyEvent).toHaveBeenTriggered();
+      });
+
       it("should activate the parent li", function() {
         var $parentLi = $("#tab-trigger-2").parents("li");
         $("#tab-trigger-2").trigger("click");


### PR DESCRIPTION
This PR close the issue #1488.

When one tab is clicked, this trigger one event called *tab:clicked*
with two arguments. The first argument is the element clicked. The
second argument is the target content that will be activated by this
tab.

You can see this in action with this code:

```javascript
function someFunction() {
  $(document).on('tab:clicked', function(evt, arg1, arg2){
    console.log(arg1, arg2);
  })
} 
```