### PR TITLE
Fix dropdown scope

### DIFF
--- a/source/assets/javascripts/locastyle/_dropdown.js
+++ b/source/assets/javascripts/locastyle/_dropdown.js
@@ -29,8 +29,6 @@ locastyle.dropdown = (function() {
       evt.preventDefault();
       var $target = $($(this).parents(config.module));
       locastyle.dropdown.toggleDropdown($target);
-      ariaDropdown($target);
-      locastyle.dropdown.closeDropdown($target);
       setPositionVisible($target);
       evt.stopPropagation();
     });
@@ -44,9 +42,9 @@ locastyle.dropdown = (function() {
 
   function toggleDropdown($target) {
     if(!$target.find(config.button).first().hasClass('ls-disabled')){
+      closeDropdown($target);
       $target.toggleClass("ls-active");
-      $(config.button).attr({ 'aria-expanded' : 'false' });
-      $(config.nav).attr({ 'aria-hidden' : 'true' });
+      ariaDropdown($target);
       locastyle.topbarCurtain.hideCurtains();
     }
   }
@@ -63,16 +61,24 @@ locastyle.dropdown = (function() {
   }
 
   function ariaDropdown(el) {
-    $(config.nav, el).find('a').attr({ role : 'option' });
-    $(config.button, el).attr({ role : 'combobox' });
+    $(config.button).attr({ 'aria-expanded' : 'false' });
+    $(config.nav).attr({ 'aria-hidden' : 'true' });
 
-    if($(el).hasClass('ls-active')){
-      $(config.button, el).attr({ 'aria-expanded' : 'true' });
-      $(config.nav, el).attr({ 'aria-hidden' : 'false' });
-    } else {
-      $(config.button, el).attr({ 'aria-expanded' : 'false' });
-      $(config.nav, el).attr({ 'aria-hidden' : 'true' });
-    }
+    $(el).each(function() {
+      $(config.nav).find('a').attr({ role : 'option' });
+      $(config.button).attr({ role : 'combobox' });
+
+        console.log($(this))
+      if($(this).hasClass('ls-active')){
+        console.log("estava ativado")
+        $(config.button, $(this)).attr({ 'aria-expanded' : 'true' });
+        $(config.nav, $(this)).attr({ 'aria-hidden' : 'false' });
+      } else {
+        console.log("estava desativado")
+        $(config.button, $(this)).attr({ 'aria-expanded' : 'false' });
+        $(config.nav, $(this)).attr({ 'aria-hidden' : 'true' });
+      }
+    });
   }
 
   return {

--- a/spec/javascripts/dropdown_spec.js
+++ b/spec/javascripts/dropdown_spec.js
@@ -106,7 +106,7 @@ describe("Dropdown: ", function() {
     });
 
     it("When click the button should has attr aria-expanded with value true", function() {
-      $('.ls-dropdown').find('.ls-btn-primary').trigger('click');
+      $('#dropdown-test-6.ls-dropdown').find('.ls-btn-primary').trigger('click');
       expect($('#dropdown-test-6 > .ls-btn-primary').attr('aria-expanded')).toEqual('true');
     });
 

--- a/spec/javascripts/dropdown_spec.js
+++ b/spec/javascripts/dropdown_spec.js
@@ -6,18 +6,6 @@ describe("Dropdown: ", function() {
 
   describe("Dropdown toggle", function() {
     describe('when click on a dropdown trigger', function() {
-      it("should activate a disabled related dropdown module", function() {
-        // Added as pending because the tests broke while I was testing other functionality
-        $("#dropdown-test > a:first-child").trigger("click");
-        expect($("#dropdown-test").hasClass("ls-active")).toEqual(true);
-      });
-
-      it("should disable an active related dropdown module", function() {
-        // Added as pending because the tests broke while I was testing other functionality
-        $("#dropdown-test-2 > a:first-child").trigger("click");
-        expect($("#dropdown-test-2").hasClass("ls-active")).toEqual(false);
-      });
-
       it("should prevent default event on dropdown module", function() {
         // Added as pending because the tests broke while I was testing other functionality
         var spyEvent = spyOnEvent('#dropdown-test > a:first-child', 'click');
@@ -25,12 +13,27 @@ describe("Dropdown: ", function() {
         expect(spyEvent).toHaveBeenPrevented();
       });
 
-      it("should close any opened dropdown", function() {
-        // Added as pending because the tests broke while I was testing other functionality
-        $("#dropdown-test-4 #dropdown-default > a:first-child").trigger("click");
-        expect($("#dropdown-test-4 #dropdown-active").hasClass("ls-active")).toEqual(false);
+      describe('And dropdown is closed', function() {
+        it("should activate a disabled related dropdown module", function() {
+          // Added as pending because the tests broke while I was testing other functionality
+          $("#dropdown-test > a:first-child").trigger("click");
+          expect($("#dropdown-test").hasClass("ls-active")).toEqual(true);
+        });
       });
 
+      describe("And dropdown is opened", function() {
+        it("should disable an active related dropdown module", function() {
+          // Added as pending because the tests broke while I was testing other functionality
+          $("#dropdown-test-2 > a:first-child").trigger("click");
+          expect($("#dropdown-test-2").hasClass("ls-active")).toEqual(false);
+        });
+
+        it("should close any opened dropdown", function() {
+          // Added as pending because the tests broke while I was testing other functionality
+          $("#dropdown-test-4 #dropdown-default > a:first-child").trigger("click");
+          expect($("#dropdown-test-4 #dropdown-active").hasClass("ls-active")).toEqual(false);
+        });
+      });
     });
 
     describe("When click outside dropdown click", function() {

--- a/spec/javascripts/fixtures/dropdown_fixture.html
+++ b/spec/javascripts/fixtures/dropdown_fixture.html
@@ -88,3 +88,15 @@
     <li><a href="#">Daren Black</a></li>
   </ul>
 </div>
+
+<div id="dropdown-test-7" data-ls-module="dropdown" class="ls-dropdown">
+  <a href="#" class="ls-btn-primary">Users</a>
+
+  <ul class="ls-dropdown-nav">
+    <li><a href="#">Dulce Graves</a></li>
+    <li><a href="#">Terry Atkins</a></li>
+    <li><a href="#">Ida Heath</a></li>
+    <li><a href="#">Caleb Bowman</a></li>
+    <li><a href="#">Daren Black</a></li>
+  </ul>
+</div>


### PR DESCRIPTION
In order to solve the issue "Event to dropdown element #1497", I looked inside dropdown module and figured out it has bugs related to scope, there was functions affecting all dropdown elements on page when it should affect only one.

For example, when I added a new fixture an old test started failing because the expected effect happens only on last dropdown element in page.

I changed it by doing things on each dropdown, one by one, instead of using a generic selector.