### PR TITLE
Add open/close events to dropdown module

### DIFF
--- a/source/assets/javascripts/locastyle/_dropdown.js
+++ b/source/assets/javascripts/locastyle/_dropdown.js
@@ -68,13 +68,10 @@ locastyle.dropdown = (function() {
       $(config.nav).find('a').attr({ role : 'option' });
       $(config.button).attr({ role : 'combobox' });
 
-        console.log($(this))
       if($(this).hasClass('ls-active')){
-        console.log("estava ativado")
         $(config.button, $(this)).attr({ 'aria-expanded' : 'true' });
         $(config.nav, $(this)).attr({ 'aria-hidden' : 'false' });
       } else {
-        console.log("estava desativado")
         $(config.button, $(this)).attr({ 'aria-expanded' : 'false' });
         $(config.nav, $(this)).attr({ 'aria-hidden' : 'true' });
       }

--- a/source/assets/javascripts/locastyle/_dropdown.js
+++ b/source/assets/javascripts/locastyle/_dropdown.js
@@ -46,6 +46,15 @@ locastyle.dropdown = (function() {
       $target.toggleClass("ls-active");
       ariaDropdown($target);
       locastyle.topbarCurtain.hideCurtains();
+      eventsHandler($target);
+    }
+  }
+
+  function eventsHandler(el) {
+    if($(el).hasClass("ls-active")) {
+      $(el).trigger('dropdown:opened');
+    } else {
+      $(el).trigger('dropdown:closed');
     }
   }
 

--- a/source/documentacao/componentes/dropdown.html.erb
+++ b/source/documentacao/componentes/dropdown.html.erb
@@ -433,4 +433,37 @@ type: component
     </table>
   </div>
 
+  <h2 class="doc-title-3">Eventos</h2>
+  <p>Você pode escutar eventos de abre e fecha nos elementos de dropdown, veja a referência abaixo.</p>
+  <table class="ls-table">
+    <thead>
+      <tr>
+        <th width="200">Evento</th>
+        <th>Descrição</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>dropdown:opened</th>
+        <td><p>Quando um dropdown abre, o evento <code>dropdown:opened</code> é disparado no elemento do módulo. Veja exemplo abaixo.</p></td>
+      </tr>
+      <tr>
+        <th>dropdown:closed</th>
+        <td><p>Quando um dropdown fecha, o evento <code>dropdown:closed</code> é disparado no elemento do módulo. Veja exemplo abaixo.</p></td>
+      </tr>
+    </tbody>
+  </table>
+  <p>Exemplo: </p>
+  <% code("javascript") do %>
+// Um dropdown específico
+$("#id-do-dropdown").on('dropdown:opened', function(){
+  // do something
+})
+
+// Todos os elementos de dropdown
+$(".ls-dropdown").on('dropdown:closed', function(){
+  // do something
+})
+  <%end%>
+
 </section>

--- a/spec/javascripts/dropdown_spec.js
+++ b/spec/javascripts/dropdown_spec.js
@@ -17,6 +17,12 @@ describe("Dropdown: ", function() {
           $("#dropdown-test > a:first-child").trigger("click");
           expect($("#dropdown-test").hasClass("ls-active")).toEqual(true);
         });
+
+        it("should trigger the event dropdown:opened", function() {
+          var spyEvent = spyOnEvent("#dropdown-test-7", 'dropdown:opened');
+          $("#dropdown-test-7 > a").trigger("click");
+          expect('dropdown:opened').toHaveBeenTriggeredOn("#dropdown-test-7");
+        });
       });
 
       describe("And dropdown is opened", function() {
@@ -28,6 +34,12 @@ describe("Dropdown: ", function() {
         it("should close any opened dropdown", function() {
           $("#dropdown-test-4 #dropdown-default > a:first-child").trigger("click");
           expect($("#dropdown-test-4 #dropdown-active").hasClass("ls-active")).toEqual(false);
+        });
+
+        it("should trigger the event dropdown:opened", function() {
+          var spyEvent = spyOnEvent(document, 'dropdown:closed');
+          $("#dropdown-test-8 > a").trigger("click");
+          expect('dropdown:closed').toHaveBeenTriggeredOn(document)
         });
       });
     });

--- a/spec/javascripts/dropdown_spec.js
+++ b/spec/javascripts/dropdown_spec.js
@@ -7,7 +7,6 @@ describe("Dropdown: ", function() {
   describe("Dropdown toggle", function() {
     describe('when click on a dropdown trigger', function() {
       it("should prevent default event on dropdown module", function() {
-        // Added as pending because the tests broke while I was testing other functionality
         var spyEvent = spyOnEvent('#dropdown-test > a:first-child', 'click');
         $("#dropdown-test > a:first-child").trigger("click");
         expect(spyEvent).toHaveBeenPrevented();
@@ -15,7 +14,6 @@ describe("Dropdown: ", function() {
 
       describe('And dropdown is closed', function() {
         it("should activate a disabled related dropdown module", function() {
-          // Added as pending because the tests broke while I was testing other functionality
           $("#dropdown-test > a:first-child").trigger("click");
           expect($("#dropdown-test").hasClass("ls-active")).toEqual(true);
         });
@@ -23,13 +21,11 @@ describe("Dropdown: ", function() {
 
       describe("And dropdown is opened", function() {
         it("should disable an active related dropdown module", function() {
-          // Added as pending because the tests broke while I was testing other functionality
           $("#dropdown-test-2 > a:first-child").trigger("click");
           expect($("#dropdown-test-2").hasClass("ls-active")).toEqual(false);
         });
 
         it("should close any opened dropdown", function() {
-          // Added as pending because the tests broke while I was testing other functionality
           $("#dropdown-test-4 #dropdown-default > a:first-child").trigger("click");
           expect($("#dropdown-test-4 #dropdown-active").hasClass("ls-active")).toEqual(false);
         });
@@ -55,7 +51,6 @@ describe("Dropdown: ", function() {
   describe("Unbind:", function() {
     describe("when unbind is called in module init", function() {
       it("should prevent toggleDropdown from being called twice or more times", function() {
-        // Added as pending because the tests broke while I was testing other functionality
         var spy = spyOn(locastyle.dropdown, "toggleDropdown");
         locastyle.dropdown.init();
         locastyle.dropdown.init();

--- a/spec/javascripts/fixtures/dropdown_fixture.html
+++ b/spec/javascripts/fixtures/dropdown_fixture.html
@@ -100,3 +100,15 @@
     <li><a href="#">Daren Black</a></li>
   </ul>
 </div>
+
+<div id="dropdown-test-8" data-ls-module="dropdown" class="ls-dropdown ls-active">
+  <a href="#" class="ls-btn-primary">Users</a>
+
+  <ul class="ls-dropdown-nav">
+    <li><a href="#">Dulce Graves</a></li>
+    <li><a href="#">Terry Atkins</a></li>
+    <li><a href="#">Ida Heath</a></li>
+    <li><a href="#">Caleb Bowman</a></li>
+    <li><a href="#">Daren Black</a></li>
+  </ul>
+</div>


### PR DESCRIPTION
First I fixed a bug: https://github.com/locaweb/locawebstyle/pull/1502

Then, created the open/close events for dropdown, you can see how it works in docs:
/documentacao/componentes/dropdown/