### PR TITLE
Changing jshint tool and created a rake task to wrap tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
 
 branches:
   only:
-    - wip
     - master
 
 before_script:
@@ -13,5 +12,4 @@ before_script:
   - sleep 3
 
 script:
-  - bundle exec rake jshint
-  - bundle exec rake jasmine:ci
+  - bundle exec rake tests:run

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'compass', '~> 1.0.0.alpha.19'
 gem 'sass', '~> 3.3.9'
 
 gem 'jasmine', '~> 2.2.0'
-gem 'jshintrb', '~> 0.3.0'
+gem 'jshint_on_rails'
 
 gem 'therubyracer' # faster JS compiles
 gem 'oj' # faster JS compiles

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 Dir.glob('scripts/tasks/*.rake').each { |r| import r }
 
-####
 # jasmine
-####
 begin
   require 'jasmine'
   load 'jasmine/tasks/jasmine.rake'
@@ -12,13 +10,9 @@ rescue LoadError
   end
 end
 
-####
-# jshint
-####
-require "jshintrb/jshinttask"
-Jshintrb::JshintTask.new :jshint do |t|
-  t.pattern = 'source/assets/javascripts/locastyle/**/*.js'
-  t.options = :jshintrc
-end
-
+# publisher
 require 'middleman-gh-pages'
+
+# jshint
+require 'jshint/tasks'
+JSHint.config_path = "spec/config_jslint.yml"

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,13 @@ We have some instructions maintain the code more legible and organized. Sorry, t
 
 [Read here the code guide of CSS](http://locaweb.github.io/locawebstyle/documentacao/praticas/css/) and [JavaScript](http://locaweb.github.io/locawebstyle/documentacao/praticas/javascript/) to maintain a good practices of this project.
 
+### Running tests
+Before sending any code, please run our automated tests:
+```sh
+$ bundle exec rake tests:run
+```
+It will run Jasmine tests and JShint.
+
 ---
 **pt-br version**
 
@@ -98,3 +105,10 @@ Para contribuir é bico: Faça um fork do projeto aqui mesmo no GitHub e comece 
 Existem algumas instruções para mantermos o código legível e organizado. [Leia essas instruções aqui](http://locaweb.github.io/locawebstyle/documentacao/introducao/contribua/).
 
 Leia também nossos padrões de código de [CSS](http://locaweb.github.io/locawebstyle/documentacao/praticas/css/) e [JavaScript](http://locaweb.github.io/locawebstyle/documentacao/praticas/javascript/).
+
+### Rodando os tests
+Antes de enviar seu código, rode nossa suite de testes:
+```sh
+$ bundle exec rake tests:run
+```
+Isso vai rodar os testes de Jasmine e o JShint.

--- a/scripts/tasks/tests.rake
+++ b/scripts/tasks/tests.rake
@@ -1,0 +1,11 @@
+# -*- coding: UTF-8 -*-
+
+namespace :tests do
+  desc "Run all Locastyle tests"
+  task :run do
+    puts "Running Jasmine tests..."
+    Rake::Task["jasmine:ci"].invoke
+
+    Rake::Task["jshint"].invoke
+  end
+end

--- a/source/assets/javascripts/locastyle/_browser-detect.js
+++ b/source/assets/javascripts/locastyle/_browser-detect.js
@@ -19,7 +19,7 @@ locastyle.browserDetect = (function() {
   }
 
   function browserVersion() {
-    return parseInt((userAgent.match(/.+(?:firefox|phantomjs|msie|chrome|version|rv)[\/: ]([\d.]+)/) || [0, 0])[1].split('.')[0] );
+    return parseInt((userAgent.match(/.+(?:firefox|phantomjs|msie|chrome|version|rv)[\/: ]([\d.]+)/) || [0, 0])[1].split('.')[0], 10);
   }
 
   function browserClass() {

--- a/source/assets/javascripts/locastyle/_general.js
+++ b/source/assets/javascripts/locastyle/_general.js
@@ -129,7 +129,7 @@ locastyle.general = (function() {
   }
 
   return {
-    init: init,
+    init: init
   };
 
 }());

--- a/source/assets/javascripts/locastyle/_initializer.js
+++ b/source/assets/javascripts/locastyle/_initializer.js
@@ -23,8 +23,10 @@ var locastyle = (function() {
   function loadModules() {
     var modules = getModules();
     for (var i in modules) {
-      locastyle[modules[i]].init();
-      console.info("Locastyle: module [" + modules[i] + "] successfully initialized.");
+      if (modules.hasOwnProperty(i)) {
+        locastyle[modules[i]].init();
+        console.info("Locastyle: module [" + modules[i] + "] successfully initialized.");
+      }
     }
   }
 

--- a/source/assets/javascripts/locastyle/_steps.js
+++ b/source/assets/javascripts/locastyle/_steps.js
@@ -151,7 +151,7 @@ locastyle.steps = (function() {
 
     $(window).scroll(function() {
      if ($(window).scrollTop() > offset.top ) {
-        var $scroll = parseInt($(window).scrollTop() - $heightNav);
+        var $scroll = parseInt($(window).scrollTop() - $heightNav, 10);
 
         $steps.stop().animate({
          marginTop: $(window).scrollTop() - offset.top + 20

--- a/source/assets/javascripts/locastyle/_track-events.js
+++ b/source/assets/javascripts/locastyle/_track-events.js
@@ -5,11 +5,11 @@ locastyle.trackEvents = (function() {
 
   function init(){
     if(window.ga){
-      this.gaPresent = true;
-      setCategory(this);
+      locastyle.trackEvents.gaPresent = true;
+      setCategory(locastyle.trackEvents);
       findTriggers();
     } else {
-      this.gaPresent = false;
+      locastyle.trackEvents.gaPresent = false;
     }
   }
 

--- a/spec/config_jslint.yml
+++ b/spec/config_jslint.yml
@@ -52,6 +52,46 @@ maxerr:   50        # The maximum number of warnings reported (per file)
 passfail: false     # true if the scan should stop on first error (per file)
 # following are relevant only if undef = true
 
+browser:  true      # true if the standard browser globals should be predefined
+rhino:    false     # true if the Rhino environment globals should be predefined
+windows:  false     # true if Windows-specific globals should be predefined
+widget:   false     # true if the Yahoo Widgets globals should be predefined
+devel:    false     # true if functions like alert, confirm, console, prompt etc. are predefined
+
+# jshint options
+loopfunc: true      # true if functions should be allowed to be defined within loops
+asi:      true      # true if automatic semicolon insertion should be tolerated
+boss:     true      # true if advanced usage of assignments and == should be allowed
+couch:    true      # true if CouchDB globals should be predefined
+curly:    true     # true if curly braces around blocks should be required (even in if/for/while)
+noarg:    true      # true if arguments.caller and arguments.callee should be disallowed
+node:     true      # true if the Node.js environment globals should be predefined
+noempty:  true      # true if empty blocks should be disallowed
+nonew:    true      # true if using `new` for side-effects should be disallowed
+
+jquery: true
+
+
+# ------------ jshint_on_rails custom lint options (switch to true to disable some annoying warnings) ------------
+
+# ignores "missing semicolon" warning at the end of a function; this lets you write one-liners
+# like: x.map(function(i) { return i + 1 }); without having to put a second semicolon inside the function
+lastsemic: false
+
+# allows you to use the 'new' expression as a statement (without assignment)
+# so you can call e.g. new Ajax.Request(...), new Effect.Highlight(...) without assigning to a dummy variable
+newstat: false
+
+# ignores the "Expected an assignment or function call and instead saw an expression" warning,
+# if the expression contains a proper statement and makes sense; this lets you write things like:
+#    element && element.show();
+#    valid || other || lastChance || alert('OMG!');
+#    selected ? show() : hide();
+# although these will still cause a warning:
+#    element && link;
+#    selected ? 5 : 10;
+statinexp: false
+
 # Names of predefined global variables - comma-separated string or a YAML array
 predef:
   - ga
@@ -201,42 +241,3 @@ predef:
   - setPositionData
   - bindActions
 
-browser:  true      # true if the standard browser globals should be predefined
-rhino:    false     # true if the Rhino environment globals should be predefined
-windows:  false     # true if Windows-specific globals should be predefined
-widget:   false     # true if the Yahoo Widgets globals should be predefined
-devel:    false     # true if functions like alert, confirm, console, prompt etc. are predefined
-
-# jshint options
-loopfunc: true      # true if functions should be allowed to be defined within loops
-asi:      true      # true if automatic semicolon insertion should be tolerated
-boss:     true      # true if advanced usage of assignments and == should be allowed
-couch:    true      # true if CouchDB globals should be predefined
-curly:    true     # true if curly braces around blocks should be required (even in if/for/while)
-noarg:    true      # true if arguments.caller and arguments.callee should be disallowed
-node:     true      # true if the Node.js environment globals should be predefined
-noempty:  true      # true if empty blocks should be disallowed
-nonew:    true      # true if using `new` for side-effects should be disallowed
-
-jquery: true
-
-
-# ------------ jshint_on_rails custom lint options (switch to true to disable some annoying warnings) ------------
-
-# ignores "missing semicolon" warning at the end of a function; this lets you write one-liners
-# like: x.map(function(i) { return i + 1 }); without having to put a second semicolon inside the function
-lastsemic: false
-
-# allows you to use the 'new' expression as a statement (without assignment)
-# so you can call e.g. new Ajax.Request(...), new Effect.Highlight(...) without assigning to a dummy variable
-newstat: false
-
-# ignores the "Expected an assignment or function call and instead saw an expression" warning,
-# if the expression contains a proper statement and makes sense; this lets you write things like:
-#    element && element.show();
-#    valid || other || lastChance || alert('OMG!');
-#    selected ? show() : hide();
-# although these will still cause a warning:
-#    element && link;
-#    selected ? 5 : 10;
-statinexp: false

--- a/spec/config_jslint.yml
+++ b/spec/config_jslint.yml
@@ -32,7 +32,7 @@ undef:    false      # true if variables must be declared before used
 white:    false     # true if strict whitespace rules apply (see also 'indent' option)
 
 # "allow" type options (false means potentially more warnings)
-
+shadow:   true
 cap:      false     # true if upper case HTML should be allowed
 css:      false     # true if CSS workarounds should be tolerated
 debug:    false     # true if debugger statements should be allowed (set to false before going into production)

--- a/spec/config_jslint.yml
+++ b/spec/config_jslint.yml
@@ -240,4 +240,5 @@ predef:
   - destroy
   - setPositionData
   - bindActions
-
+  - closeDropdown
+  - eventsHandler

--- a/spec/config_jslint.yml
+++ b/spec/config_jslint.yml
@@ -46,7 +46,7 @@ sub:      false     # true if subscript notation may be used for expressions bet
 
 # other options
 
-maxlen:   160       # Maximum line length
+maxlen:   260       # Maximum line length
 indent:   2         # Number of spaces that should be used for indentation - used only if 'white' option is set
 maxerr:   50        # The maximum number of warnings reported (per file)
 passfail: false     # true if the scan should stop on first error (per file)

--- a/spec/config_jslint.yml
+++ b/spec/config_jslint.yml
@@ -1,0 +1,91 @@
+# ------------ rake task options ------------
+
+# JS files to check by default, if no parameters are passed to rake jshint
+# (you may want to limit this only to your own scripts and exclude any external scripts and frameworks)
+
+# this can be overridden by adding 'paths' and 'exclude_paths' parameter to rake command:
+#   rake jshint paths=path1,path2,... exclude_paths=library1,library2,...
+
+paths:
+  - source/assets/javascripts/locastyle/**/*.js
+
+exclude_paths:
+
+
+# ------------ jshint options ------------
+# visit http://jshint.com/ for complete documentation
+
+# "enforce" type options (true means potentially more warnings)
+
+adsafe:   false     # true if ADsafe rules should be enforced. See http://www.ADsafe.org/
+bitwise:  true      # true if bitwise operators should not be allowed
+newcap:   true      # true if Initial Caps must be used with constructor functions
+eqeqeq:   false     # true if === should be required (for ALL equality comparisons)
+immed:    false     # true if immediate function invocations must be wrapped in parens
+nomen:    false     # true if initial or trailing underscore in identifiers should be forbidden
+onevar:   false     # true if only one var statement per function should be allowed
+plusplus: false     # true if ++ and -- should not be allowed
+regexp:   false     # true if . and [^...] should not be allowed in RegExp literals
+safe:     false     # true if the safe subset rules are enforced (used by ADsafe)
+strict:   false     # true if the ES5 "use strict"; pragma is required
+undef:    true      # true if variables must be declared before used
+white:    false     # true if strict whitespace rules apply (see also 'indent' option)
+
+# "allow" type options (false means potentially more warnings)
+
+cap:      false     # true if upper case HTML should be allowed
+css:      false     # true if CSS workarounds should be tolerated
+debug:    false     # true if debugger statements should be allowed (set to false before going into production)
+es5:      false     # true if ECMAScript 5 syntax should be allowed
+evil:     false     # true if eval should be allowed
+forin:    false     # true if unfiltered 'for in' statements should be allowed
+fragment: false     # true if HTML fragments should be allowed
+laxbreak: false     # true if statement breaks should not be checked
+on:       false     # true if HTML event handlers (e.g. onclick="...") should be allowed
+sub:      false     # true if subscript notation may be used for expressions better expressed in dot notation
+
+# other options
+
+maxlen:   160       # Maximum line length
+indent:   2         # Number of spaces that should be used for indentation - used only if 'white' option is set
+maxerr:   50        # The maximum number of warnings reported (per file)
+passfail: false     # true if the scan should stop on first error (per file)
+# following are relevant only if undef = true
+predef:   ''        # Names of predefined global variables - comma-separated string or a YAML array
+browser:  true      # true if the standard browser globals should be predefined
+rhino:    false     # true if the Rhino environment globals should be predefined
+windows:  false     # true if Windows-specific globals should be predefined
+widget:   false     # true if the Yahoo Widgets globals should be predefined
+devel:    false     # true if functions like alert, confirm, console, prompt etc. are predefined
+
+# jshint options
+loopfunc: true      # true if functions should be allowed to be defined within loops
+asi:      true      # true if automatic semicolon insertion should be tolerated
+boss:     true      # true if advanced usage of assignments and == should be allowed
+couch:    true      # true if CouchDB globals should be predefined
+curly:    false     # true if curly braces around blocks should be required (even in if/for/while)
+noarg:    true      # true if arguments.caller and arguments.callee should be disallowed
+node:     true      # true if the Node.js environment globals should be predefined
+noempty:  true      # true if empty blocks should be disallowed
+nonew:    true      # true if using `new` for side-effects should be disallowed
+
+
+# ------------ jshint_on_rails custom lint options (switch to true to disable some annoying warnings) ------------
+
+# ignores "missing semicolon" warning at the end of a function; this lets you write one-liners
+# like: x.map(function(i) { return i + 1 }); without having to put a second semicolon inside the function
+lastsemic: false
+
+# allows you to use the 'new' expression as a statement (without assignment)
+# so you can call e.g. new Ajax.Request(...), new Effect.Highlight(...) without assigning to a dummy variable
+newstat: false
+
+# ignores the "Expected an assignment or function call and instead saw an expression" warning,
+# if the expression contains a proper statement and makes sense; this lets you write things like:
+#    element && element.show();
+#    valid || other || lastChance || alert('OMG!');
+#    selected ? show() : hide();
+# although these will still cause a warning:
+#    element && link;
+#    selected ? 5 : 10;
+statinexp: false

--- a/spec/config_jslint.yml
+++ b/spec/config_jslint.yml
@@ -20,15 +20,15 @@ exclude_paths:
 adsafe:   false     # true if ADsafe rules should be enforced. See http://www.ADsafe.org/
 bitwise:  true      # true if bitwise operators should not be allowed
 newcap:   true      # true if Initial Caps must be used with constructor functions
-eqeqeq:   false     # true if === should be required (for ALL equality comparisons)
-immed:    false     # true if immediate function invocations must be wrapped in parens
+eqeqeq:   true     # true if === should be required (for ALL equality comparisons)
+immed:    true     # true if immediate function invocations must be wrapped in parens
 nomen:    false     # true if initial or trailing underscore in identifiers should be forbidden
 onevar:   false     # true if only one var statement per function should be allowed
 plusplus: false     # true if ++ and -- should not be allowed
 regexp:   false     # true if . and [^...] should not be allowed in RegExp literals
 safe:     false     # true if the safe subset rules are enforced (used by ADsafe)
 strict:   false     # true if the ES5 "use strict"; pragma is required
-undef:    true      # true if variables must be declared before used
+undef:    false      # true if variables must be declared before used
 white:    false     # true if strict whitespace rules apply (see also 'indent' option)
 
 # "allow" type options (false means potentially more warnings)
@@ -38,7 +38,7 @@ css:      false     # true if CSS workarounds should be tolerated
 debug:    false     # true if debugger statements should be allowed (set to false before going into production)
 es5:      false     # true if ECMAScript 5 syntax should be allowed
 evil:     false     # true if eval should be allowed
-forin:    false     # true if unfiltered 'for in' statements should be allowed
+forin:    true     # true if unfiltered 'for in' statements should be allowed
 fragment: false     # true if HTML fragments should be allowed
 laxbreak: false     # true if statement breaks should not be checked
 on:       false     # true if HTML event handlers (e.g. onclick="...") should be allowed
@@ -51,7 +51,156 @@ indent:   2         # Number of spaces that should be used for indentation - use
 maxerr:   50        # The maximum number of warnings reported (per file)
 passfail: false     # true if the scan should stop on first error (per file)
 # following are relevant only if undef = true
-predef:   ''        # Names of predefined global variables - comma-separated string or a YAML array
+
+# Names of predefined global variables - comma-separated string or a YAML array
+predef:
+  - ga
+  - bindSelects
+  - findLinks
+  - findButtons
+  - findForms
+  - findSelects
+  - bindGuidedTour
+  - bindClickEvents
+  - bindClickEvents
+  - bindFormEvents
+  - bindCloseCurtains
+  - bindPreventClosing
+  - repositionOnResize
+  - updateStatusCounter
+  - bindTopCurtainTrigger
+  - hideCurtains
+  - hideCurtains
+  - showCurtain
+  - setCategory
+  - updateTriggerLink
+  - dropdownShape
+  - JST
+  - unbind
+  - positionTarget
+  - activateElement
+  - bindClickOnTriggers
+  - bindBreakpointUpdateOnChecker
+  - checkBreakpoint
+  - ariaTabs
+  - deactivateTab
+  - activateTab
+  - isDropdownMode
+  - findTriggers
+  - structureProgressBar
+  - setProgressBarValue
+  - checkStatus
+  - addArrowToggle
+  - sidebarToggling
+  - checkStatus
+  - maximizeMobile
+  - minimizeSidebar
+  - maximizeSidebar
+  - maximizeSidebar
+  - minimizeSidebar
+  - notificationVerification
+  - bindShowSidebar
+  - bindShowNotifications
+  - userAccountVerification
+  - prepareSubmenu
+  - submenu
+  - openSubmenuItemActive
+  - whenSidebarToggling
+  - clickAnywhereCloseSubmenu
+  - ariaMenu
+  - ariaSubmenu
+  - sidebarVisibleClass
+  - notificationClassVisible
+  - closeSubmenu
+  - openSubmenu
+  - ariaSubmenu
+  - ariaSubmenu
+  - ariaSubmenu
+  - createArrow
+  - ariaSteps
+  - addAriaLabel
+  - addActivedNav
+  - bindNextStep
+  - bindPrevStep
+  - activateStep
+  - addActiveContent
+  - stepsAffix
+  - changeStep
+  - nextStep
+  - prevStep
+  - changeStep
+  - changeStep
+  - activateStep
+  - deactivateStep
+  - anchorSteps
+  - addActivedButton
+  - bindClick
+  - deactivateElement
+  - removeChecked
+  - deactivateElement
+  - ariaAlert
+  - breakpointWindowWidth
+  - breakpointScreenWidth
+  - changeClassBreakpoint
+  - browserClass
+  - browserDetect
+  - hideBrowserUnsupportedAlert
+  - openUsupportedBrowserAlert
+  - group
+  - countText
+  - updateCounter
+  - ariaCollapse
+  - bind
+  - groupCollapse
+  - toggle
+  - ariaCollapse
+  - checkVisible
+  - checkVisible
+  - create
+  - checkTarget
+  - dismiss
+  - bindClickOutsideTriggers
+  - ariaDropdown
+  - ariaDropdown
+  - setPositionVisible
+  - formDisable
+  - formText
+  - masks
+  - textareaAutoresize
+  - prefixSufix
+  - togglePasswordField
+  - textareaHeight
+  - _toggleClass
+  - _toggleText
+  - _smoothScroll
+  - _unbind
+  - _autoTrigger
+  - _loadEvents
+  - _elementDisabled
+  - _linkPreventDefault
+  - _btnGroupActivationToogle
+  - _toggleFields
+  - checkTour
+  - setTour
+  - setCookie
+  - initTour
+  - keyCode
+  - hopscotch
+  - loadModules
+  - checkClassForTrack
+  - getModules
+  - bindOpen
+  - modalBlocked
+  - fadeIn
+  - ariaModal
+  - modalBlocked
+  - fadeOut
+  - createPopover
+  - updateBreakpoint
+  - destroy
+  - setPositionData
+  - bindActions
+
 browser:  true      # true if the standard browser globals should be predefined
 rhino:    false     # true if the Rhino environment globals should be predefined
 windows:  false     # true if Windows-specific globals should be predefined
@@ -63,11 +212,13 @@ loopfunc: true      # true if functions should be allowed to be defined within l
 asi:      true      # true if automatic semicolon insertion should be tolerated
 boss:     true      # true if advanced usage of assignments and == should be allowed
 couch:    true      # true if CouchDB globals should be predefined
-curly:    false     # true if curly braces around blocks should be required (even in if/for/while)
+curly:    true     # true if curly braces around blocks should be required (even in if/for/while)
 noarg:    true      # true if arguments.caller and arguments.callee should be disallowed
 node:     true      # true if the Node.js environment globals should be predefined
 noempty:  true      # true if empty blocks should be disallowed
 nonew:    true      # true if using `new` for side-effects should be disallowed
+
+jquery: true
 
 
 # ------------ jshint_on_rails custom lint options (switch to true to disable some annoying warnings) ------------


### PR DESCRIPTION
The task was to create a rake task and wrap jasmine and jshint tests, but I figure out the older jshint wasn't checking all important things, also there was no config to set what we want and what we don't want to check.

Now the config lives in: spec/config_jshint.yml
We can keep tuning and improving the checks as we want.