### PR TITLE
Adds open/close events to popover

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'eco'
 gem 'compass', '~> 1.0.0.alpha.19'
 gem 'sass', '~> 3.3.9'
 
-gem 'jasmine', '~> 2.2.0'
+gem 'jasmine', '~> 2.3.0'
 gem 'jshintrb', '~> 0.3.0'
 
 gem 'therubyracer' # faster JS compiles

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -115,10 +115,12 @@ locastyle.popover = (function() {
 
   function open($popover) {
     $popover.addClass(config.activeClass).show();
+    $popover.trigger('popover:opened');
   }
 
   function close($popover) {
     $popover.stop().removeClass(config.activeClass).hide();
+    $popover.trigger('popover:closed');
   }
 
   function destroy() {

--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -92,4 +92,40 @@ type: component
     <a href="#" class="ls-word-dotted" data-ls-module="popover" title="Titulo" data-content="Conteúdo do popover">Popover</a>
   </div>
   <% code("html") do %><a href="#" class="ls-word-dotted" data-ls-module="popover" title="Titulo" data-content="Conteúdo do popover">Popover</a><% end %>
+
+
+  <h2 class="doc-title-3">Eventos</h2>
+  <p>Você pode escutar eventos de abre e fecha nos elementos de popover, isto é bom porque estes elementos são criados pelo próprio módulo e normalmente não sabemos identificá-los, com os eventos basta procurar pelo elemento onde foi disparado o evento e pronto.</p>
+  <table class="ls-table">
+    <thead>
+      <tr>
+        <th width="200">Evento</th>
+        <th>Descrição</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>popover:opened</th>
+        <td><p>Quando um popover abre, o evento <code>popover:opened</code> é disparado no elemento do popover, aquele que recebe a classe <code>ls-popover</code>. Veja exemplo abaixo.</p></td>
+      </tr>
+      <tr>
+        <th>popover:closed</th>
+        <td><p>Quando um popover fecha, o evento <code>popover:closed</code> é disparado no elemento do popover, aquele que recebe a classe <code>ls-popover</code>. Veja exemplo abaixo.</p></td>
+      </tr>
+    </tbody>
+  </table>
+  <p>Exemplo: </p>
+<% code("javascript") do %>
+// Um popover específico, caso você saiba o ID
+// (os IDs dos popovers são atribuidos pelo próprio módulo)
+$("#id-do-popover").on('popover:opened', function(){
+  // do something
+})
+
+// Todos os elementos de popover
+$(".ls-popover").on('popover:closed', function(){
+  // do something
+})
+<%end%>
+
 </section>

--- a/spec/javascripts/popover_spec.js
+++ b/spec/javascripts/popover_spec.js
@@ -40,6 +40,14 @@ describe('Popover: ', function() {
       expect($('.ls-popover').eq(0).css('display')).toEqual("none");
     });
 
+    it("Should trigger the event dropdown:opened when it opens by click", function() {
+      var id = $('.ls-popover').eq(0).attr("id");
+      var popoverToOpen = "#" + id;
+      var spyEvent = spyOnEvent(popoverToOpen, 'popover:opened');
+      $("#popoverclick").trigger("click");
+      expect('popover:opened').toHaveBeenTriggeredOn(popoverToOpen);
+    });
+
     it('Should remove ls-active class on closed popover', function() {
       $('.ls-popover').hide();
       $('#popoverclick').trigger('click');
@@ -47,11 +55,27 @@ describe('Popover: ', function() {
       expect($('.ls-popover').eq(0).hasClass('ls-active')).toEqual(false);
     });
 
+    it("Should trigger the event dropdown:closed when it closes by click", function() {
+      var id = $('.ls-popover').eq(0).attr("id");
+      var popoverToClose = "#" + id;
+      var spyEvent = spyOnEvent(popoverToClose, 'popover:closed');
+      $("#popoverclick").trigger("click");
+      $("#popoverclick").trigger("click");
+      expect('popover:closed').toHaveBeenTriggeredOn(popoverToClose);
+    });
 
     it('Should show a popover on hover event', function() {
       $('.ls-popover').hide();
       $('#popoverhover').trigger('mouseenter');
       expect($('.ls-popover').eq(1).css('display')).toEqual("block");
+    });
+
+    it("Should trigger the event dropdown:opened when it opens by mouseenter", function() {
+      var id = $('.ls-popover').eq(1).attr("id");
+      var popoverToOpen = "#" + id;
+      var spyEvent = spyOnEvent(popoverToOpen, 'popover:opened');
+      $('#popoverhover').trigger('mouseenter');
+      expect('popover:opened').toHaveBeenTriggeredOn(popoverToOpen);
     });
 
     it('Should close a popover on mouseleave event', function() {
@@ -60,6 +84,16 @@ describe('Popover: ', function() {
       $('#popoverhover').trigger('mouseleave');
       expect($('.ls-popover').eq(1).css('display')).toEqual("none");
     });
+
+    it("Should trigger the event dropdown:closed when it closes by mouseout", function() {
+      var id = $('.ls-popover').eq(1).attr("id");
+      var popoverToClose = "#" + id;
+      var spyEvent = spyOnEvent(popoverToClose, 'popover:closed');
+      $('#popoverhover').trigger('mouseenter');
+      $('#popoverhover').trigger('mouseleave');
+      expect('popover:closed').toHaveBeenTriggeredOn(popoverToClose);
+    });
+
 
   });
 

--- a/spec/javascripts/popover_spec.js
+++ b/spec/javascripts/popover_spec.js
@@ -1,6 +1,7 @@
 describe('Popover: ', function() {
   beforeEach(function() {
     loadFixtures('popover_fixture.html');
+    locastyle.breakpointClass = "ls-window-lg";
     locastyle.popover.init();
   });
 


### PR DESCRIPTION
In order to add the events I did a little refactor in popovers, also fixed the tests that broke only in jasmine:ci, when runned by phantomjs.

So we have:
* module refactoring
* tests working on CI
* events when open and close

To know how it works and test it, see the docs.

Resolves the issue #1495