### PR TITLE
Improving docs to make ordination classes easier to understand

### DIFF
--- a/source/documentacao/componentes/tabelas.html.erb
+++ b/source/documentacao/componentes/tabelas.html.erb
@@ -126,7 +126,7 @@ type: component
   </table>
 
   <h2 class="doc-title-3">Ordenação nas tabelas</h2>
-  <p>Perceba que para deixar os títulos de colunas com marcação de ordenação, basta utilizar as classes <code>.ls-data-descending</code> ou <code>.ls-data-ascending </code>.</p>
+  <p>Perceba que para deixar os títulos de colunas com marcação de ordenação, é necessário ter uma tag <code>a</code> dentro da tag <code>th</code>, depois disso, basta utilizar as classes <code>.ls-data-descending</code> ou <code>.ls-data-ascending </code>.</p>
   <p>Isso <strong>não adiciona uma funcionalidade de ordenação</strong>, apenas as setinhas de marcação.</p>
   <table class="ls-table">
     <thead>


### PR DESCRIPTION
I was asked about how to show ordination arrows in tables and figured out it needs an A tag inside the TH tag in order to work.

It was not clear in docs, so I added it.