### PR TITLE
New Popover - Fix #1547

### DIFF
--- a/source/assets/javascripts/locastyle/_modal.js
+++ b/source/assets/javascripts/locastyle/_modal.js
@@ -61,7 +61,7 @@ locastyle.modal = (function() {
   function open(button) {
     var $element = button.data(),
         $target = null;
-    
+
     $('body').addClass(config.classes.open);
 
     if (!$element.target) {
@@ -72,7 +72,7 @@ locastyle.modal = (function() {
     } else {
       $target = $($element.target);
     }
-    
+
     $target.addClass('ls-opened');
 
     // This event return two arguments: element clicked and target.
@@ -89,15 +89,12 @@ locastyle.modal = (function() {
 
     $this.attr('aria-hidden', true);
     $this.removeClass('ls-opened');
-    
-    unbindClose();
 
-    locastyle.popover.destroyPopover(); //add trigger on popover
-    locastyle.popover.init(); ///add trigger on popover
+    unbindClose();
 
     // This event return one argument: element target.
     $this.trigger(config.close.triggerClosed);
-    
+
     if($this.hasClass('ls-modal-template')) {
       $this.remove();
     }

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -35,77 +35,89 @@ locastyle.popover = (function() {
     });
   }
 
-  function buildPopover(index, el) {
-    var data = {
-      index        : index,
-      title        : $(el).data('title'),
-      content      : $(el).data('content'),
-      placement    : $(el).data('placement'),
-      customClasses: $(el).data('custom-class')
-    }
-    setTarget(index, el);
-    $(config.container).append(locastyle.templates.popover(data));
-    setPosition(index, el);
+  // Build the HTML of popovers using a template
+  function buildPopover() {
+    $(document).on(config.events.checkedExistence, function(event, index, popoverTrigger){
+      var data = {
+        index        : index,
+        title        : $(popoverTrigger).data('title'),
+        content      : $(popoverTrigger).data('content'),
+        placement    : $(popoverTrigger).data('placement'),
+        customClasses: $(popoverTrigger).data('custom-class')
+      }
+      $(config.container).append(locastyle.templates.popover(data));
+      $(document).trigger(config.events.builded, [index, popoverTrigger]);
+    });
   }
 
-  // Define position of popover
-  function setPosition(index, el) {
-    var data = {
-        target    : $(el).data('target'),
-        top       : $(el).offset().top,
-        left      : $(el).offset().left,
-        width     : $(el).outerWidth(),
-        height    : $(el).outerHeight(),
-        placement : $(el).data('placement')
-    }
-    calcPosition(data);
+  // Define popover target that will be called
+  function setTarget() {
+    $(document).on(config.events.builded, function(event, index, popoverTrigger){
+      $(popoverTrigger).attr('data-target', config.idPopover+index);
+      $(document).trigger(config.events.targetSetted, [popoverTrigger]);
+    });
   }
 
-  // Calc the position of popover called
-  function calcPosition(data) {
-    var style;
-    switch (data.placement) {
-      case 'top':
-        $(data.target).css({
-          top : data.top  -=  12,
-          left: data.left += (data.width/2 + 4)
-        });
-        break;
-      case 'right':
-        $(data.target).css({
-          top : data.top  += (data.height/2 -2),
-          left: data.left += (data.width + 12)
-        });
-        break;
-      case 'bottom':
-        $(data.target).css({
-          top : data.top  += (data.height + 12),
-          left: data.left += (data.width/2 + 4)
-        });
-        break;
-      case 'left':
-        $(data.target).css({
-          top : data.top  += (data.height/2 -2 ),
-          left: data.left -= 12
-        });
-    }
-  }
-
+  // When click or hover elements, show the popovers
   function bindPopover() {
-    $(document).on(config.events.created, function() {
+    $(document).on(config.events.created, function(event, popoverTrigger) {
 
-      // if ( !$(config.module).attr('data-trigger', 'hover').length ){
-      //   console.log('true')
-      // }
-      //
-      // var trigger = $(config.module).data('trigger') === 'hover' ? 'mouseover' : config.trigger;
+      var trigger = $(popoverTrigger).attr('data-trigger') === 'hover' ? 'mouseover' : config.trigger;
 
-      $(config.module).on('click', function() {
+      $(popoverTrigger).on(trigger, function() {
         $(this).trigger(config.events.clicked);
         show($(this).data('target'));
       });
+
     });
   }
+
+  // Define position of popovers
+  function setPosition() {
+    $(document).on(config.events.targetSetted, function(event, popoverTrigger){
+
+      // Get the informations to position the popovers
+      var data = {
+          target    : $(popoverTrigger).data('target'),
+          top       : $(popoverTrigger).offset().top,
+          left      : $(popoverTrigger).offset().left,
+          width     : $(popoverTrigger).outerWidth(),
+          height    : $(popoverTrigger).outerHeight(),
+          placement : $(popoverTrigger).data('placement')
+      }
+
+      // Define the position of popovers and your elements triggers
+      switch (data.placement) {
+        case 'top':
+          $(data.target).css({
+            top : data.top  -=  12,
+            left: data.left += (data.width/2 + 4)
+          });
+          break;
+        case 'right':
+          $(data.target).css({
+            top : data.top  += (data.height/2 -2),
+            left: data.left += (data.width + 12)
+          });
+          break;
+        case 'bottom':
+          $(data.target).css({
+            top : data.top  += (data.height + 12),
+            left: data.left += (data.width/2 + 4)
+          });
+          break;
+        case 'left':
+          $(data.target).css({
+            top : data.top  += (data.height/2 -2 ),
+            left: data.left -= 12
+          });
+      }
+
+      // Communicate that all popovers was created.
+      $(document).trigger(config.events.created, [popoverTrigger]);
+    });
+  }
+
 
   // Show called popover
   function show(target) {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -102,9 +102,11 @@ locastyle.popover = (function() {
         height    : $(popoverTrigger).outerHeight(),
         placement : $(popoverTrigger).data('placement')
     }
+    console.log(data.target)
 
     // Define the position of popovers and your elements triggers
     switch (data.placement) {
+      default:
       case 'top':
         $(data.target).css({
           top : data.top  -=  12,

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -110,7 +110,6 @@ locastyle.popover = (function() {
   // When click or hover elements, show the popovers
   function bindPopover() {
     $(document).on(config.events.created, function(event, popoverTrigger, popoverTarget) {
-
       var trigger = $(popoverTrigger).attr('data-trigger') === 'hover' ? 'mouseover' : config.trigger;
 
       $(popoverTrigger).on(trigger, function() {
@@ -119,8 +118,14 @@ locastyle.popover = (function() {
         } else {
           show(popoverTarget);
         }
+
         $(popoverTrigger).trigger(config.events.called, [popoverTrigger, popoverTarget]);
       });
+      if (trigger === 'mouseover') {
+        $(popoverTrigger).on('mouseout', function() {
+          hide(popoverTarget);
+        });
+      }
     });
   }
 

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -8,6 +8,7 @@ locastyle.popover = (function() {
     module       : '[data-ls-module="popover"]',
     idPopover    : '#ls-popover-',
     popoverClass : '.ls-popover',
+    trigger      : 'click',
     events: {
       created: 'popover:ready',
       clicked: 'popover:clicked',
@@ -16,7 +17,7 @@ locastyle.popover = (function() {
 
   function init() {
     checkExists();
-    setPosition();
+    bindPopover();
   }
 
   function checkExists() {
@@ -26,11 +27,10 @@ locastyle.popover = (function() {
       }
     });
     $(document).trigger(config.events.created);
-    bindPopover();
   }
 
   function buildPopover(index, el) {
-    var elementData = {
+    var data = {
       index        : index,
       title        : $(el).data('title'),
       content      : $(el).data('content'),
@@ -38,77 +38,87 @@ locastyle.popover = (function() {
       customClasses: $(el).data('custom-class')
     }
     setTarget(index, el);
-    $(config.container).append(locastyle.templates.popover(elementData));
+    $(config.container).append(locastyle.templates.popover(data));
+    setPosition(index, el);
   }
 
-  function setTarget(index, el) {
-    $(el).attr('data-target', config.idPopover+index);
+  // Define position of popover
+  function setPosition(index, el) {
+    var data = {
+        target    : $(el).data('target'),
+        top       : $(el).offset().top,
+        left      : $(el).offset().left,
+        width     : $(el).outerWidth(),
+        height    : $(el).outerHeight(),
+        placement : $(el).data('placement')
+    }
+    calcPosition(data);
   }
 
-  function bindPopover() {
-    $(document).on(config.events.created, function() {
-      $(config.module).on('click', function() {
-        $(this).trigger(config.events.clicked);
-      });
-    });
-  }
-
-  function setPosition(element) {
-    $(config.module).on(config.events.clicked, function(event, target) {
-      var element = event.target;
-      var data = {
-          target    : $(element).data('target'),
-          top       : $(element).offset().top,
-          left      : $(element).offset().left,
-          width     : $(element).outerWidth(),
-          height    : $(element).outerHeight(),
-          placement : $(element).data('placement')
-      }
-      calcPosition(data);
-      $(data.target).show();
-    });
-  }
-
+  // Calc the position of popover called
   function calcPosition(data) {
     var style;
     switch (data.placement) {
       case 'top':
-        style = {
+        $(data.target).css({
           top : data.top  -=  12,
           left: data.left += (data.width/2 + 4)
-        }
+        });
         break;
       case 'right':
-        style = {
+        $(data.target).css({
           top : data.top  += (data.height/2 -2),
           left: data.left += (data.width + 12)
-        }
+        });
         break;
       case 'bottom':
-        style = {
+        $(data.target).css({
           top : data.top  += (data.height + 12),
           left: data.left += (data.width/2 + 4)
-        }
+        });
         break;
       case 'left':
-        style = {
+        $(data.target).css({
           top : data.top  += (data.height/2 -2 ),
           left: data.left -= 12
-        }
+        });
     }
-    return $(data.target).css(style);
   }
 
+  function bindPopover() {
+    $(document).on(config.events.created, function() {
+
+      // if ( !$(config.module).attr('data-trigger', 'hover').length ){
+      //   console.log('true')
+      // }
+      //
+      // var trigger = $(config.module).data('trigger') === 'hover' ? 'mouseover' : config.trigger;
+
+      $(config.module).on('click', function() {
+        $(this).trigger(config.events.clicked);
+        show($(this).data('target'));
+      });
+    });
+  }
+
+  // Show called popover
   function show(target) {
-    $('[data-target="' + target + '"]').trigger(config.events.clicked);
+    $(target).show();
   }
 
+  // Hide all or visible popovers
   function hide(target) {
     $(target || config.popoverClass+':visible').hide();
   }
 
+  // Destroy all created popovers
   function destroy() {
     $(config.popoverClass).remove();
+  }
+
+  // Define popover target that will be called
+  function setTarget(index, el) {
+    $(el).attr('data-target', config.idPopover+index);
   }
 
   return {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -61,20 +61,6 @@ locastyle.popover = (function() {
     });
   }
 
-  // When click or hover elements, show the popovers
-  function bindPopover() {
-    $(document).on(config.events.created, function(event, popoverTrigger) {
-
-      var trigger = $(popoverTrigger).attr('data-trigger') === 'hover' ? 'mouseover' : config.trigger;
-
-      $(popoverTrigger).on(trigger, function() {
-        $(this).trigger(config.events.called);
-        show($(this).data('target'));
-      });
-
-    });
-  }
-
   // Define position of popovers
   function setPosition() {
     $(document).on(config.events.targetSetted, function(event, popoverTrigger){
@@ -117,20 +103,36 @@ locastyle.popover = (function() {
       }
 
       // Communicate that all popovers was created.
-      $(document).trigger(config.events.created, [popoverTrigger]);
+      $(document).trigger(config.events.created, [popoverTrigger, data.target]);
     });
   }
 
+  // When click or hover elements, show the popovers
+  function bindPopover() {
+    $(document).on(config.events.created, function(event, popoverTrigger, popoverTarget) {
+
+      var trigger = $(popoverTrigger).attr('data-trigger') === 'hover' ? 'mouseover' : config.trigger;
+
+      $(popoverTrigger).on(trigger, function() {
+        if ($(popoverTarget).hasClass('ls-active')) {
+          hide(popoverTarget);
+        } else {
+          show(popoverTarget);
+        }
+        $(popoverTrigger).trigger(config.events.called, [popoverTrigger, popoverTarget]);
+      });
+    });
+  }
 
   // Show called popover
   function show(target) {
-    $(target).show();
+    $(target).addClass('ls-active');
     $(target).trigger(config.events.opened);
   }
 
   // Hide all or visible popovers
   function hide(target) {
-    $(target || config.popoverClass+':visible').hide();
+    $(target || config.popoverClass+':visible').removeClass('ls-active');
     $(target).trigger(config.events.closed);
   }
 

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -4,17 +4,13 @@ locastyle.popover = (function() {
   'use strict';
 
   var config = {
-    module    : '[data-ls-module="popover"]',
-    idPopover : '#ls-popover-',
-    popovers  : '.ls-popover',
+    container    : 'body',
+    module       : '[data-ls-module="popover"]',
+    idPopover    : '#ls-popover-',
+    popoverClass : '.ls-popover',
     events: {
-      ready  : 'popover:ready',
+      created: 'popover:ready',
       clicked: 'popover:clicked',
-    },
-    init: {
-      container : 'body',
-      trigger   : 'click.ls.popover',
-      uniqueId  : 0
     }
   }
 
@@ -29,22 +25,20 @@ locastyle.popover = (function() {
         buildPopover(index, el);
       }
     });
-
-    $(document).trigger(config.events.ready);
+    $(document).trigger(config.events.created);
     bindPopover();
   }
 
   function buildPopover(index, el) {
     var elementData = {
-      index : index,
-      title    : $(el).data('title'),
-      content  : $(el).data('content'),
-      placement: $(el).data('placement')
+      index        : index,
+      title        : $(el).data('title'),
+      content      : $(el).data('content'),
+      placement    : $(el).data('placement'),
+      customClasses: $(el).data('custom-class')
     }
-
     setTarget(index, el);
-
-    $(config.init.container).append(locastyle.templates.popover(elementData));
+    $(config.container).append(locastyle.templates.popover(elementData));
   }
 
   function setTarget(index, el) {
@@ -52,7 +46,7 @@ locastyle.popover = (function() {
   }
 
   function bindPopover() {
-    $(document).on(config.events.ready, function() {
+    $(document).on(config.events.created, function() {
       $(config.module).on('click', function() {
         $(this).trigger(config.events.clicked);
       });
@@ -61,27 +55,67 @@ locastyle.popover = (function() {
 
   function setPosition(element) {
     $(config.module).on(config.events.clicked, function(event, target) {
-      var element = event.target,
-          target = $(element).data('target'),
-          top = $(element).offset().top,
-          left = $(element).offset().left
-      showPopover(target);
+      var element = event.target;
+      var data = {
+          target    : $(element).data('target'),
+          top       : $(element).offset().top,
+          left      : $(element).offset().left,
+          width     : $(element).outerWidth(),
+          height    : $(element).outerHeight(),
+          placement : $(element).data('placement')
+      }
+      calcPosition(data);
+      $(data.target).show();
     });
   }
 
-  function showPopover(target) {
-    hidePopover(target);
-    $(target).show();
+  function calcPosition(data) {
+    var style;
+    switch (data.placement) {
+      case 'top':
+        style = {
+          top : data.top  -=  12,
+          left: data.left += (data.width/2 + 4)
+        }
+        break;
+      case 'right':
+        style = {
+          top : data.top  += (data.height/2 -2),
+          left: data.left += (data.width + 12)
+        }
+        break;
+      case 'bottom':
+        style = {
+          top : data.top  += (data.height + 12),
+          left: data.left += (data.width/2 + 4)
+        }
+        break;
+      case 'left':
+        style = {
+          top : data.top  += (data.height/2 -2 ),
+          left: data.left -= 12
+        }
+    }
+    return $(data.target).css(style);
   }
 
-  function hidePopover(target) {
-    $(config.popovers+':visible' || target).hide();
+  function show(target) {
+    $('[data-target="' + target + '"]').trigger(config.events.clicked);
+  }
+
+  function hide(target) {
+    $(target || config.popoverClass+':visible').hide();
+  }
+
+  function destroy() {
+    $(config.popoverClass).remove();
   }
 
   return {
-    init: init,
-    show: showPopover,
-    hide: hidePopover
+    init   : init,
+    show   : show,
+    hide   : hide,
+    destroy: destroy
   };
 
 }());

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -57,7 +57,6 @@ locastyle.popover = (function() {
       if(!$(event.target).parents('.ls-popover').length){
         hide(target);
       }
-      console.log('yeah')
     });
   }
 
@@ -102,7 +101,6 @@ locastyle.popover = (function() {
         height    : $(popoverTrigger).outerHeight(),
         placement : $(popoverTrigger).data('placement')
     }
-    console.log(data.target)
 
     // Define the position of popovers and your elements triggers
     switch (data.placement) {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -20,6 +20,7 @@ locastyle.popover = (function() {
     clickAnywhereClose();
     buildPopover();
     bindPopover();
+    startOpened();
   }
 
   // When click or hover elements, show the popovers
@@ -59,6 +60,12 @@ locastyle.popover = (function() {
     });
   }
 
+  // When open page, start popover automatically
+  function startOpened() {
+    $(config.module+'[data-ls-popover="open"]').each(function() {
+      show($(this).data('target'));
+    });
+  }
 
   // If popover was not created, we build the HTML using a template
   function buildPopover() {
@@ -126,18 +133,12 @@ locastyle.popover = (function() {
 
   // Show called popover
   function show(target) {
-    $(target).on(config.events.opened, function(){
-      console.log('opened', target)
-    });
     $(target).addClass('ls-active');
     $(target).off(config.events.closed).trigger(config.events.opened);
   }
 
   // Hide all or visible popovers
   function hide(target) {
-    $(target).on(config.events.closed, function(){
-      console.log('closed', target)
-    });
     $(target || '.ls-popover.ls-active').removeClass('ls-active');
     $(target).trigger(config.events.closed).off(config.events.opened)
     $(document).off(config.events.clickAnywhere)

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -114,11 +114,12 @@ locastyle.popover = (function() {
   // Destroy all created popovers
   function destroy() {
     $(config.popoverClass).remove();
-  }
 
-  // Define popover target that will be called
-  function setTarget(index, el) {
-    $(el).attr('data-target', config.idPopover+index);
+    // Unbind all events.
+    $.each(config.events, function(index, event) {
+      $(document).unbind(event);
+    });
+
   }
 
   return {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -4,138 +4,46 @@ locastyle.popover = (function() {
   'use strict';
 
   var config = {
-    container    : 'body',
-    hoverEvent   : 'mouseenter.ls.popover',
-    idPopover    : '#ls-popover-',
-    module       : '[data-ls-module="popover"]',
-    placement    : 'top',
-    trigger      : 'click.ls.popover',
-    popoverClass : 'ls-popover',
-    activeClass  : 'ls-active',
-    uniqueId     : 0
-  };
+    module: '[data-ls-module="popover"]',
+    init: {
+      $container    : $(document),
+      idPopover    : '#ls-popover-',
+      trigger      : 'click.ls.popover',
+      popoverClass : 'ls-popover',
+      activeClass  : 'ls-active',
+      uniqueId     : 0
+    }
+  }
 
   function init() {
-    if(/sm|xs/.test(locastyle.breakpointClass)){
-      $(config.module).attr('data-ls-module', 'modal').removeAttr('data-trigger');
-      locastyle.modal.init();
-    } else{
-      $(config.module).each(function  (index, elem) {
-        createPopover($(elem));
-      });
-    }
-    updateBreakpoint();
+    checkExists();
   }
 
-  function updateBreakpoint() {
-    $(window).on("breakpoint-updated", function () {
-      destroy();
-      init();
+  function checkExists() {
+    $(config.module).each(function(index, el) {
+
+      if(!$(config.init.idPopover+index).length) {
+        buildPopover(index, el);
+      }
+
     });
   }
 
-  function createPopover($elem) {
-    var elementData = $elem.data(),
-        width  = $elem.outerWidth(),
-        height = $elem.outerHeight();
-    $elem.data('uniqueId', config.uniqueId);
-    elementData.position  = elementData.container ? $elem.position() : $elem.offset() ;
-    elementData.container = elementData.container || config.container;
-    elementData.placement = elementData.placement || config.placement;
-    setPositionData(elementData, width, height);
-    elementData.uniqueId = config.uniqueId++;
-    $(elementData.container).append(locastyle.templates.popover(elementData));
-    bindActions($elem, elementData, width, height);
-  }
-
-  function setPositionData(elementData, width, height) {
-    switch (elementData.placement) {
-      case 'top':
-        elementData.position.top -=  12;
-        elementData.position.left +=  (width/2 + 4);
-        break;
-      case 'right':
-        elementData.position.top +=  (height/2 -2);
-        elementData.position.left += (width + 12);
-        break;
-      case 'bottom':
-        elementData.position.top += (height + 12);
-        elementData.position.left +=  (width/2 + 4);
-        break;
-      case 'left':
-        elementData.position.top +=  (height/2 -2 );
-        elementData.position.left -= 12;
+  function buildPopover(index, el) {
+    var elementData = {
+      index : index,
+      title    : $(el).data('title'),
+      content  : $(el).data('content'),
+      placement: $(el).data('placement')
     }
+
+    $(el).after(locastyle.templates.popover(elementData));
   }
 
-  function updateElementPosition($popover, elementData) {
-    $popover.css("top", elementData.position.top).css("left", elementData.position.left);
-  }
 
-  function bindActions($elem, elementData, width, height) {
-    var trigger = elementData.trigger === 'hover' ? config.hoverEvent : config.trigger,
-        $popover = $(config.idPopover + elementData.uniqueId);
-    if(trigger === config.hoverEvent){
-      $elem.on({
-        mouseenter: function(event) {
-          event.preventDefault();
-          elementData.position = $(this).offset() ;
-          setPositionData(elementData, width, height);
-          updateElementPosition($popover, elementData);
-          open($popover);
-        },
-        mouseleave: function (event) {
-          event.preventDefault();
-          close($popover);
-        }
-      });
-    } else {
-      $elem.on({
-        click: function(event) {
-          event.preventDefault();
-          event.stopPropagation();
-          elementData.position = $(this).offset() ;
-          setPositionData(elementData, width, height);
-          updateElementPosition($popover, elementData);
-          if($popover.hasClass("ls-active")) {
-            close($popover);
-          } else {
-            open($popover);
-          }
-        }
-      });
-      $(document).on('click', function(event) {
-        var element = event.toElement;
-        if(!$(element).parents().hasClass( config.popoverClass )){
-          close($('.' + config.popoverClass));
-        }
-      });
-    }
-  }
-
-  function open($popover) {
-    $popover.addClass(config.activeClass).show();
-    $popover.trigger('popover:opened');
-  }
-
-  function close($popover) {
-    $popover.stop().removeClass(config.activeClass).hide();
-    $popover.trigger('popover:closed');
-  }
-
-  function destroy() {
-    $('.' + config.popoverClass).remove();
-    $(config.module).each(function  (index, elem) {
-      $(elem)
-        .removeData('uniqueId')
-        .off(config.hoverEvent)
-        .off(config.trigger);
-    });
-  }
 
   return {
-    init: init,
-    destroyPopover: destroy
+    init: init
   };
 
 }());

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -19,8 +19,11 @@ locastyle.popover = (function() {
   }
 
   function init() {
-    checkExists();
     bindPopover();
+    setPosition();
+    setTarget();
+    buildPopover();
+    checkExists();
   }
 
   function checkExists() {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -104,13 +104,6 @@ locastyle.popover = (function() {
 
     // Define the position of popovers and your elements triggers
     switch (data.placement) {
-      default:
-      case 'top':
-        $(data.target).css({
-          top : data.top  -=  12,
-          left: data.left += (data.width/2 + 4)
-        });
-        break;
       case 'right':
         $(data.target).css({
           top : data.top  += (data.height/2 -2),
@@ -128,6 +121,14 @@ locastyle.popover = (function() {
           top : data.top  += (data.height/2 -2 ),
           left: data.left -= 12
         });
+        break;
+      default:
+      case 'top':
+        $(data.target).css({
+          top : data.top  -=  12,
+          left: data.left += (data.width/2 + 4)
+        });
+
     }
 
   }

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -10,8 +10,11 @@ locastyle.popover = (function() {
     popoverClass : '.ls-popover',
     trigger      : 'click',
     events: {
-      created: 'popover:ready',
+      created: 'popover:created',
       clicked: 'popover:clicked',
+      builded: 'popover:builded',
+      targetSetted: 'popover:hastarget',
+      checkedExistence: 'popover:exist'
     }
   }
 

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -11,7 +11,7 @@ locastyle.popover = (function() {
     trigger      : 'click',
     events: {
       created: 'popover:created',
-      clicked: 'popover:clicked',
+      called: 'popover:called',
       builded: 'popover:builded',
       targetSetted: 'popover:hastarget',
       checkedExistence: 'popover:exist'

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -26,13 +26,13 @@ locastyle.popover = (function() {
     checkExists();
   }
 
+  // Check if popovers exists. If not, create that.
   function checkExists() {
     $(config.module).each(function(index, el) {
       if(!$(config.idPopover+index).length) {
-        buildPopover(index, el);
+        $(document).trigger(config.events.checkedExistence, [index, el]);
       }
     });
-    $(document).trigger(config.events.created);
   }
 
   function buildPopover(index, el) {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -12,6 +12,9 @@ locastyle.popover = (function() {
     events: {
       created: 'popover:created',
       called: 'popover:called',
+      opened: 'popover:opened',
+      closed: 'popover:closed',
+      destroyed: 'popover:destroyed',
       builded: 'popover:builded',
       targetSetted: 'popover:hastarget',
       checkedExistence: 'popover:exist'
@@ -65,7 +68,7 @@ locastyle.popover = (function() {
       var trigger = $(popoverTrigger).attr('data-trigger') === 'hover' ? 'mouseover' : config.trigger;
 
       $(popoverTrigger).on(trigger, function() {
-        $(this).trigger(config.events.clicked);
+        $(this).trigger(config.events.called);
         show($(this).data('target'));
       });
 
@@ -122,11 +125,13 @@ locastyle.popover = (function() {
   // Show called popover
   function show(target) {
     $(target).show();
+    $(target).trigger(config.events.opened);
   }
 
   // Hide all or visible popovers
   function hide(target) {
     $(target || config.popoverClass+':visible').hide();
+    $(target).trigger(config.events.closed);
   }
 
   // Destroy all created popovers
@@ -138,6 +143,7 @@ locastyle.popover = (function() {
       $(document).unbind(event);
     });
 
+    $(document).trigger(config.events.destroyed);
   }
 
   return {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -88,6 +88,11 @@ locastyle.popover = (function() {
         // Define position of popovers based on his triggers
         setPosition(popoverTrigger);
       }
+
+      $(window).on('breakpoint-updated', function(){
+        setPosition(popoverTrigger);
+      });
+
     });
   }
 

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -57,6 +57,7 @@ locastyle.popover = (function() {
       if(!$(event.target).parents('.ls-popover').length){
         hide(target);
       }
+      console.log('yeah')
     });
   }
 
@@ -141,8 +142,13 @@ locastyle.popover = (function() {
   function hide(target) {
     $(target || '.ls-popover.ls-active').removeClass('ls-active');
     $(target).trigger(config.events.closed).off(config.events.opened)
-    $(document).off(config.events.clickAnywhere)
+
+    if(!$('.ls-popover.ls-active').length) {
+      $(document).off(config.events.clickAnywhere)
+    }
+
   }
+
 
   // Destroy all created popovers
   function destroy() {

--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -4,29 +4,34 @@ locastyle.popover = (function() {
   'use strict';
 
   var config = {
-    module: '[data-ls-module="popover"]',
+    module    : '[data-ls-module="popover"]',
+    idPopover : '#ls-popover-',
+    popovers  : '.ls-popover',
+    events: {
+      ready  : 'popover:ready',
+      clicked: 'popover:clicked',
+    },
     init: {
-      $container    : $(document),
-      idPopover    : '#ls-popover-',
-      trigger      : 'click.ls.popover',
-      popoverClass : 'ls-popover',
-      activeClass  : 'ls-active',
-      uniqueId     : 0
+      container : 'body',
+      trigger   : 'click.ls.popover',
+      uniqueId  : 0
     }
   }
 
   function init() {
     checkExists();
+    setPosition();
   }
 
   function checkExists() {
     $(config.module).each(function(index, el) {
-
-      if(!$(config.init.idPopover+index).length) {
+      if(!$(config.idPopover+index).length) {
         buildPopover(index, el);
       }
-
     });
+
+    $(document).trigger(config.events.ready);
+    bindPopover();
   }
 
   function buildPopover(index, el) {
@@ -37,13 +42,46 @@ locastyle.popover = (function() {
       placement: $(el).data('placement')
     }
 
-    $(el).after(locastyle.templates.popover(elementData));
+    setTarget(index, el);
+
+    $(config.init.container).append(locastyle.templates.popover(elementData));
   }
 
+  function setTarget(index, el) {
+    $(el).attr('data-target', config.idPopover+index);
+  }
 
+  function bindPopover() {
+    $(document).on(config.events.ready, function() {
+      $(config.module).on('click', function() {
+        $(this).trigger(config.events.clicked);
+      });
+    });
+  }
+
+  function setPosition(element) {
+    $(config.module).on(config.events.clicked, function(event, target) {
+      var element = event.target,
+          target = $(element).data('target'),
+          top = $(element).offset().top,
+          left = $(element).offset().left
+      showPopover(target);
+    });
+  }
+
+  function showPopover(target) {
+    hidePopover(target);
+    $(target).show();
+  }
+
+  function hidePopover(target) {
+    $(config.popovers+':visible' || target).hide();
+  }
 
   return {
-    init: init
+    init: init,
+    show: showPopover,
+    hide: hidePopover
   };
 
 }());

--- a/source/assets/javascripts/locastyle/templates/_popover.jst.eco
+++ b/source/assets/javascripts/locastyle/templates/_popover.jst.eco
@@ -1,4 +1,4 @@
-<div id="ls-popover-<%= @index %>" class="ls-popover ls-popover-<%= @placement || "top" %>">
+<div id="ls-popover-<%= @index %>" class="ls-popover ls-popover-<%= @placement || "top" %> <%= @customClasses %>">
   <% if @title :%>
   <div class="ls-popover-header">
     <h3 class="title-3"> <%= @title %> </h3>

--- a/source/assets/javascripts/locastyle/templates/_popover.jst.eco
+++ b/source/assets/javascripts/locastyle/templates/_popover.jst.eco
@@ -1,4 +1,4 @@
-<div id="ls-popover-<%= @uniqueId %>" class="ls-popover ls-popover-<%= @placement %> <%= @customClasses %>" style="top:<%= @position.top %>px; left:<%= @position.left %>px;<% if @lsPopover == 'open': %>display: block;<% end %>">
+<div id="ls-popover-<%= @index %>" class="ls-box ls-popoveXr ls-popover-<%= @placement || "top" %>">
   <% if @title :%>
   <div class="ls-popover-header">
     <h3 class="title-3"> <%= @title %> </h3>

--- a/source/assets/javascripts/locastyle/templates/_popover.jst.eco
+++ b/source/assets/javascripts/locastyle/templates/_popover.jst.eco
@@ -1,4 +1,4 @@
-<div id="ls-popover-<%= @index %>" class="ls-box ls-popoveXr ls-popover-<%= @placement || "top" %>">
+<div id="ls-popover-<%= @index %>" class="ls-popover ls-popover-<%= @placement || "top" %>">
   <% if @title :%>
   <div class="ls-popover-header">
     <h3 class="title-3"> <%= @title %> </h3>

--- a/source/assets/stylesheets/locastyle/modules/_popover.sass
+++ b/source/assets/stylesheets/locastyle/modules/_popover.sass
@@ -14,6 +14,9 @@ $colorBorderPop: rgba(0, 0, 0, 0.2)
   background-clip: padding-box
   display: none
 
+  &.ls-active
+    display: block
+
   &.ls-popover-top
     +transform( translateX( -50% ) translateY(-100%) )
 

--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -59,22 +59,26 @@ type: component
       <tr>
         <td>data-custom-classes</td>
         <td>classe</td>
-        <td>-</td>
+        <td>--</td>
         <td>permite inserir qualquer classe para customização do popover. Os valores colocados aqui, serão herdados pelo elemento do popover</td>
       </tr>
     </tbody>
   </table>
 
-  <h2 class="doc-title-3">Exemplo utilizando os parâmetros default do popover</h2>
-  <div class="ls-box-demo">
-    <a href="#" class="ls-btn-primary" data-ls-module="popover" title="Titulo" data-content="Conteúdo do popover">Popover</a>
-  </div>
-  <% code("html") do %><a href="#" class="ls-btn-primary" data-ls-module="popover" title="Titulo" data-content="Conteúdo do popover">Popover</a><% end %>
-
   <h2 class="doc-title-3">Popover aberto ao carregar a página</h2>
   <p>Basta adicionar o atributo <code>data-ls-popover="open"</code>. </p>
+
   <div class="ls-box-demo">
-    <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="right" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página"></a>
+    <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="top" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página"></a>
+    <br>
+    <br>
+    <a href="#" class="ls-btn-primary" data-ls-module="popover" data-placement="right" data-ls-popover="open" data-title="Titulo do popover" data-content="<ul class='ls-no-list-style'>
+      <li>Lista 1</li>
+      <li>Lista 2</li>
+      <li>Lista 3</li>
+    </ul>" data-placement="top">
+      Start opened
+    </a>
   </div>
   <% code("html") do %>
     <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="right" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página."></a>
@@ -90,24 +94,16 @@ type: component
     </thead>
     <tbody>
       <tr>
-        <th>popover:created</th>
-        <td><p>Quando um popover abre, o evento <code>popover:opened</code> é disparado no elemento do popover, aquele que recebe a classe <code>ls-popover</code>. Veja exemplo abaixo.</p></td>
-      </tr>
-      <tr>
         <th>popover:closed</th>
         <td><p>Quando um popover fecha, o evento <code>popover:closed</code> é disparado no elemento do popover, aquele que recebe a classe <code>ls-popover</code>. Veja exemplo abaixo.</p></td>
       </tr>
       <tr>
-        <th>popover:called</th>
+        <th>popover:opened</th>
         <td><p>Quando o elemento que chama o popover é clicado (ou quando ouver hover), ele emite um evento chamado <code>popover:called</code>
       </tr>
       <tr>
         <th>popover:destroyed</th>
         <td><p>Quando os a função <code>locastyle.popover.destroy()</code> é acionado, ele emite um evento chamado <code>popover:destroyed</code></code>
-      </tr>
-      <tr>
-        <th>popover:builded</th>
-        <td><p>Quando o HTML do popover é criado, um trigger  <code>popover:builded</code> é disparado no <code>document</code> com o nome do elemento que chama este determinado popover.
       </tr>
     </tbody>
   </table>

--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -111,7 +111,7 @@ type: component
       </tr>
     </tbody>
   </table>
-  
+
   <p>Exemplo: </p>
 <% code("javascript") do %>
 // Um popover específico, caso você saiba o ID

--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -33,7 +33,7 @@ type: component
     <tbody>
       <tr>
         <td>data-trigger</td>
-        <td>click / hover</td>
+        <td>hover</td>
         <td>click</td>
         <td>cria o popover baseado na posição do elemento</td>
       </tr>

--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -15,11 +15,6 @@ type: component
   </div>
   <% code("html") do %><%= partial 'documentacao/shared/popover' %><% end %>
 
-  <div class="ls-alert-info">
-    <h4 class="doc-title-5">No mobile, vira modal</h4>
-    <p>Quando resolução abaixo de 769px o popover muda seu comportamento e é exibido como uma modal, evitando problemas de usabilidade!</p>
-  </div>
-
   <h2 class="doc-title-3">Como usar</h2>
   <table class="ls-table">
     <thead>
@@ -32,10 +27,16 @@ type: component
     </thead>
     <tbody>
       <tr>
+        <td>data-ls-module</td>
+        <td>popover</td>
+        <td>-</td>
+        <td>inicia o módulo de popover. Deve ser colocado no elemento que chamará o popover</td>
+      </tr>
+      <tr>
         <td>data-trigger</td>
         <td>hover</td>
-        <td>click</td>
-        <td>cria o popover baseado na posição do elemento</td>
+        <td>-</td>
+        <td>define qual a interação pelo qual o popover irá aparecer. Por padrão, o popover só aparece com click, mas esse atributo substitui o click pelo <code>hover</code></td>
       </tr>
       <tr>
         <td>data-placement</td>
@@ -46,14 +47,8 @@ type: component
       <tr>
         <td>data-title</td>
         <td>text</td>
-        <td>--</td>
+        <td>-</td>
         <td>insere o título no popover</td>
-      </tr>
-      <tr>
-        <td>data-container</td>
-        <td>classe ou id</td>
-        <td>body</td>
-        <td>posiciona o popover de acordo com elemento clicado</td>
       </tr>
       <tr>
         <td>data-content</td>
@@ -64,8 +59,8 @@ type: component
       <tr>
         <td>data-custom-classes</td>
         <td>classe</td>
-        <td>--</td>
-        <td>permite inserir qualquer classe para customização do popover</td>
+        <td>-</td>
+        <td>permite inserir qualquer classe para customização do popover. Os valores colocados aqui, serão herdados pelo elemento do popover</td>
       </tr>
     </tbody>
   </table>
@@ -76,7 +71,6 @@ type: component
   </div>
   <% code("html") do %><a href="#" class="ls-btn-primary" data-ls-module="popover" title="Titulo" data-content="Conteúdo do popover">Popover</a><% end %>
 
-
   <h2 class="doc-title-3">Popover aberto ao carregar a página</h2>
   <p>Basta adicionar o atributo <code>data-ls-popover="open"</code>. </p>
   <div class="ls-box-demo">
@@ -86,16 +80,7 @@ type: component
     <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="right" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página."></a>
   <% end %>
 
-
-  <h2 class="doc-title-3">Exemplo classe funcional .ls-word-dotted</h2>
-  <div class="ls-box-demo">
-    <a href="#" class="ls-word-dotted" data-ls-module="popover" title="Titulo" data-content="Conteúdo do popover">Popover</a>
-  </div>
-  <% code("html") do %><a href="#" class="ls-word-dotted" data-ls-module="popover" title="Titulo" data-content="Conteúdo do popover">Popover</a><% end %>
-
-
   <h2 class="doc-title-3">Eventos</h2>
-  <p>Você pode escutar eventos de abre e fecha nos elementos de popover, isto é bom porque estes elementos são criados pelo próprio módulo e normalmente não sabemos identificá-los, com os eventos basta procurar pelo elemento onde foi disparado o evento e pronto.</p>
   <table class="ls-table">
     <thead>
       <tr>
@@ -105,27 +90,40 @@ type: component
     </thead>
     <tbody>
       <tr>
-        <th>popover:opened</th>
+        <th>popover:created</th>
         <td><p>Quando um popover abre, o evento <code>popover:opened</code> é disparado no elemento do popover, aquele que recebe a classe <code>ls-popover</code>. Veja exemplo abaixo.</p></td>
       </tr>
       <tr>
         <th>popover:closed</th>
         <td><p>Quando um popover fecha, o evento <code>popover:closed</code> é disparado no elemento do popover, aquele que recebe a classe <code>ls-popover</code>. Veja exemplo abaixo.</p></td>
       </tr>
+      <tr>
+        <th>popover:called</th>
+        <td><p>Quando o elemento que chama o popover é clicado (ou quando ouver hover), ele emite um evento chamado <code>popover:called</code>
+      </tr>
+      <tr>
+        <th>popover:destroyed</th>
+        <td><p>Quando os a função <code>locastyle.popover.destroy()</code> é acionado, ele emite um evento chamado <code>popover:destroyed</code></code>
+      </tr>
+      <tr>
+        <th>popover:builded</th>
+        <td><p>Quando o HTML do popover é criado, um trigger  <code>popover:builded</code> é disparado no <code>document</code> com o nome do elemento que chama este determinado popover.
+      </tr>
     </tbody>
   </table>
+  
   <p>Exemplo: </p>
 <% code("javascript") do %>
 // Um popover específico, caso você saiba o ID
 // (os IDs dos popovers são atribuidos pelo próprio módulo)
 $("#id-do-popover").on('popover:opened', function(){
   // do something
-})
+});
 
 // Todos os elementos de popover
 $(".ls-popover").on('popover:closed', function(){
   // do something
-})
+});
 <%end%>
 
 </section>

--- a/source/documentacao/shared/_popover.erb
+++ b/source/documentacao/shared/_popover.erb
@@ -1,6 +1,13 @@
 <a href="#" class="ls-btn-primary" data-ls-module="popover" data-trigger="hover" data-title="Titulo do popover 3" data-content="<p>Conteúdo do popover 3</p>" data-placement="left">
   Hover (left)
 </a>
+<a href="#" class="ls-btn-primary" data-ls-module="popover" data-ls-popover="open" data-title="Titulo do popover 2" data-content="<ul class='ls-no-list-style'>
+  <li>Lista 1</li>
+  <li>Lista 2</li>
+  <li>Lista 3</li>
+</ul>" data-placement="top">
+  Start opened
+</a>
 <a href="#" class="ls-btn-primary" data-ls-module="popover" data-title="Titulo do popover 2" data-content="<ul class='ls-no-list-style'>
   <li>Lista 1</li>
   <li>Lista 2</li>

--- a/source/documentacao/shared/_popover.erb
+++ b/source/documentacao/shared/_popover.erb
@@ -11,7 +11,7 @@
 <a href="#" class="ls-btn-primary" data-ls-module="popover" data-title="Titulo do popover 1" data-content="<p>Conteúdo do popover 1 Conteúdo do popover 1 Conteúdo do popover 1 Conteúdo do popover 1 Conteúdo do popover 1 </p>" data-placement="bottom">
   Click (bottom)
 </a>
-<a href="#" class="ls-btn-primary" data-custom-class="ls-color-danger" data-ls-module="popover" data-title="Titulo do popover 4" data-content="<p>Conteúdo do popover 4</p>" data-placement="right">
+<a href="#" class="ls-btn-primary" data-custom-class="ls-color-success" data-ls-module="popover" data-title="Titulo do popover 4" data-content="<p>Conteúdo do popover 4</p>" data-placement="right">
   Click (right)
 </a>
 

--- a/spec/config_jslint.yml
+++ b/spec/config_jslint.yml
@@ -248,3 +248,10 @@ predef:
   - eventHandler
   - Pikaday
   - createWithRange
+  - clickAnywhereClose
+  - buildPopover
+  - bindPopover
+  - startOpened
+  - hide
+  - show
+  - setPosition

--- a/spec/javascripts/fixtures/popover_fixture.html
+++ b/spec/javascripts/fixtures/popover_fixture.html
@@ -1,7 +1,8 @@
 <div id="myPopoverGroup">
 
-  <a id="popoverclick" href="#" data-ls-module="popover" data-trigger="click" data-title="Titulo do popover 1" data-content="Conteúdo do popover 1" data-placement="bottom">Popover 1</a>
-
+  <a id="popoverclick" href="#" class="ls-btn-primary" data-ls-module="popover" data-title="Titulo do popover 1" data-content="<p>Conteúdo do popover 1</p>" data-placement="left">
+    Popover 1
+  </a>
   <a id="popoverhover" href="#" data-ls-module="popover" data-trigger="hover" data-title="Titulo do popover 2" data-content="Conteúdo do popover 2" data-placement="bottom">Popover 2</a>
 
 </div>

--- a/spec/javascripts/fixtures/popover_fixture.html
+++ b/spec/javascripts/fixtures/popover_fixture.html
@@ -1,8 +1,10 @@
 <div id="myPopoverGroup">
-
-  <a id="popoverclick" href="#" class="ls-btn-primary" data-ls-module="popover" data-title="Titulo do popover 1" data-content="<p>Conteúdo do popover 1</p>" data-placement="left">
+  <a id="popoverclick" href="#" class="ls-btn-primary" data-ls-module="popover" data-title="Titulo do popover 1" data-content="<p>Conteúdo do popover 1</p>" data-placement="right">
     Popover 1
   </a>
-  <a id="popoverhover" href="#" data-ls-module="popover" data-trigger="hover" data-title="Titulo do popover 2" data-content="Conteúdo do popover 2" data-placement="bottom">Popover 2</a>
+  <a id="popoverclick2" href="#" class="ls-btn-primary" data-ls-module="popover" data-title="Titulo do popover 2" data-content="<p>Conteúdo do popover 2</p>" data-placement="left">
+    Popover 2
+  </a>
+  <a id="popoverhover" href="#" data-ls-module="popover" data-trigger="hover" data-title="Titulo do popover 3" data-content="Conteúdo do popover 3" data-placement="bottom">Popover 3</a>
 
 </div>

--- a/spec/javascripts/libs/templates.js
+++ b/spec/javascripts/libs/templates.js
@@ -17,7 +17,7 @@
             }),
             function() {
                 (function() {
-                    n.push('<div id="ls-popover-'), n.push(e(this.uniqueId)), n.push('" class="ls-popover ls-popover-'), n.push(e(this.placement)), n.push(" "), n.push(e(this.customClasses)), n.push('" style="top:'), n.push(e(this.position.top)), n.push("px; left:"), n.push(e(this.position.left)), n.push('px;">\n  '), this.title && (n.push('\n  <div class="ls-popover-header">\n    <h3 class="title-3"> '), n.push(e(this.title)), n.push(" </h3>\n  </div>\n  ")), n.push("\n  "), this.content && n.push("\n  "), n.push('\n  <div class="ls-popover-content"> '), n.push(this.content), n.push(" </div>\n</div>\n")
+                    n.push('<div id="ls-popover-'), n.push(e(this.index)), n.push('" class="ls-popover ls-popover-'), n.push(e(this.placement)), n.push(" "), n.push(e(this.customClasses)), n.push('" style="top: 13px; left: 13px;">'), this.title && (n.push('\n  <div class="ls-popover-header">\n    <h3 class="title-3"> '), n.push(e(this.title)), n.push(" </h3>\n  </div>\n  ")), n.push("\n  "), this.content && n.push("\n  "), n.push('\n  <div class="ls-popover-content"> '), n.push(this.content), n.push(" </div>\n</div>\n")
                 }).call(this)
             }.call(s), s.safe = l, s.escape = i, n.join("")
     }

--- a/spec/javascripts/popover_spec.js
+++ b/spec/javascripts/popover_spec.js
@@ -2,9 +2,9 @@ describe('Popover: ', function() {
   beforeEach(function() {
     loadFixtures('popover_fixture.html');
     locastyle.breakpointClass = "ls-window-lg";
-    locastyle.popover.destroy();
     locastyle.popover.init();
   });
+
 
   describe('Popover creation', function() {
 
@@ -34,68 +34,57 @@ describe('Popover: ', function() {
     });
 
     it('Should add ls-active class on opened popover', function() {
-      $('#popoverclick').click(); // click to open
-      expect($('.ls-popover').eq(0)).toHaveClass('ls-active');
+      $('#popoverclick2').click(); // click to open
+      var target = $('#popoverclick2').data('target');
+      expect($(target)).toHaveClass('ls-active');
     });
 
     // Click Closing Popover
     it('Should close .ls-popover removing class ls-active', function() {
-      $('#popoverclick').click(); // click to open
-      $('#popoverclick').click(); // and now click to close
-      expect($('.ls-popover').eq(0).hasClass('ls-active')).toEqual(false);
+      $('#popoverclick2').click(); // click to open
+      var target = $('#popoverclick2').data('target');
+      expect($(target).hasClass('ls-active')).toEqual(false);
     });
 
     it("Should trigger the event popover:closed when it closes by click", function() {
-      var id = $('.ls-popover').eq(0).attr("id");
-      var popoverToOpen = "#" + id;
-      var spyEvent = spyOnEvent(popoverToOpen, 'popover:closed');
-      $('#popoverclick').click(); // click to open
+      var target = $('#popoverclick').data('target');
+      var spyEvent = spyOnEvent($(target), 'popover:closed');
       $('#popoverclick').click(); // and now click to close
-      expect('popover:closed').toHaveBeenTriggeredOn(popoverToOpen);
+      expect('popover:closed').toHaveBeenTriggeredOn( $(target));
     });
 
     // Hover Opening Popover
-    it('Should show a popover on hover event', function() {
+    it('Should show a popover on hover event and trigger popover:opened', function() {
+      var target = $('#popoverhover').data('target');
+      var spyEvent = spyOnEvent($(target), 'popover:opened');
       $('#popoverhover').trigger('mouseenter');
-      expect($('.ls-popover').eq(1)).toHaveClass('ls-active');
-    });
-
-    it("Should trigger the event popover:opened when it opens by mouseenter", function() {
-      var id = $('.ls-popover').eq(1).attr("id");
-      var popoverToOpen = "#" + id;
-      var spyEvent = spyOnEvent(popoverToOpen, 'popover:opened');
-      $('#popoverhover').trigger('mouseenter');
-      expect('popover:opened').toHaveBeenTriggeredOn(popoverToOpen);
+      expect('popover:opened').toHaveBeenTriggeredOn($(target));
+      expect($(target)).toHaveClass('ls-active');
     });
 
     it('Should close a popover on mouseleave event', function() {
-      $('#popoverhover').trigger('mouseleave');
-      expect($('.ls-popover').eq(1).hasClass('ls-active')).toEqual(false);
-    });
-
-    it("Should trigger the event popover:closed when it closes by mouseout", function() {
-      var id = $('.ls-popover').eq(1).attr("id");
-      var popoverToClose = "#" + id;
-      var spyEvent = spyOnEvent(popoverToClose, 'popover:closed');
+      var target = $('#popoverhover').data('target');
+      var spyEvent = spyOnEvent($(target), 'popover:closed');
       $('#popoverhover').trigger('mouseenter');
       $('#popoverhover').trigger('mouseleave');
-      expect('popover:closed').toHaveBeenTriggeredOn(popoverToClose);
+      expect('popover:closed').toHaveBeenTriggeredOn($(target));
+      expect($(target).hasClass('ls-active')).toEqual(false);
     });
-  });
 
-  // Testing Unbind
-  describe('[unbind] When init is called multiple times', function () {
+    // Testing Unbind
+    describe('[unbind] When init is called multiple times', function () {
 
-    it('should bind events on popover elements only one time', function () {
-      locastyle.init();
-      locastyle.init();
-      locastyle.init();
-      var $popoverTrigger = $('#popoverclick');
-      var $popover = $('#ls-popover-' + $popoverTrigger.data('idPopover'));
-      $popover.hide();
-      $popoverTrigger.click();
-      $popoverTrigger.click();
-      expect( $popover ).not.toBeVisible();
+      it('should bind events on popover elements only one time', function () {
+        locastyle.init();
+        locastyle.init();
+        locastyle.init();
+        var $popoverTrigger = $('#popoverclick');
+        var $popover = $('#ls-popover-' + $popoverTrigger.data('idPopover'));
+        $popover.hide();
+        $popoverTrigger.click();
+        $popoverTrigger.click();
+        expect( $popover ).not.toBeVisible();
+      });
     });
   });
 

--- a/spec/javascripts/popover_spec.js
+++ b/spec/javascripts/popover_spec.js
@@ -2,75 +2,65 @@ describe('Popover: ', function() {
   beforeEach(function() {
     loadFixtures('popover_fixture.html');
     locastyle.breakpointClass = "ls-window-lg";
+    locastyle.popover.destroy();
     locastyle.popover.init();
-  });
-
-  afterEach(function() {
-      locastyle.popover.destroyPopover();
   });
 
   describe('Popover creation', function() {
 
+    // Create popover to each trigger elements
     it('Should create one popover for each trigger', function() {
-      var elems     = document.querySelectorAll('[data-ls-module="popover"]').length;
+      var elems    = document.querySelectorAll('[data-ls-module="popover"]').length;
       var popovers = document.querySelectorAll('.ls-popover').length;
       expect(elems).toEqual(popovers);
+    });
+
+    // Adding the attribute data-target to identify popovers and triggers
+    it('Should have data-target attr on popover trigger', function() {
+      expect($('#popoverclick')).toHaveAttr("data-target","#ls-popover-0");
     });
 
   });
 
   describe('Popover behavior', function() {
 
-    it('Should show a popover on click event', function() {
-      $('.ls-popover').hide();
-      $('#popoverclick').trigger("click");
-      expect($('.ls-popover').eq(0).css('display')).toEqual("block");
-    });
-
-    it('Should add ls-active class on opened popover', function() {
-      $('.ls-popover').hide();
-      $('#popoverclick').trigger("click");
-      expect($('.ls-popover').eq(0).hasClass('ls-active')).toEqual(true);
-    });
-
-    it('Should show and close .ls-popover on repeated click events', function() {
-      $('.ls-popover').hide();
-      $('#popoverclick').trigger('click');
-      $('#popoverclick').trigger('click');
-      expect($('.ls-popover').eq(0).css('display')).toEqual("none");
-    });
-
-    it("Should trigger the event dropdown:opened when it opens by click", function() {
+    // Click Opening Popover
+    it("Should trigger the event popover:opened when it opens by click", function() {
       var id = $('.ls-popover').eq(0).attr("id");
       var popoverToOpen = "#" + id;
       var spyEvent = spyOnEvent(popoverToOpen, 'popover:opened');
-      $("#popoverclick").trigger("click");
+      $('#popoverclick').click(); // click to open
       expect('popover:opened').toHaveBeenTriggeredOn(popoverToOpen);
     });
 
-    it('Should remove ls-active class on closed popover', function() {
-      $('.ls-popover').hide();
-      $('#popoverclick').trigger('click');
-      $('#popoverclick').trigger("click");
+    it('Should add ls-active class on opened popover', function() {
+      $('#popoverclick').click(); // click to open
+      expect($('.ls-popover').eq(0)).toHaveClass('ls-active');
+    });
+
+    // Click Closing Popover
+    it('Should close .ls-popover removing class ls-active', function() {
+      $('#popoverclick').click(); // click to open
+      $('#popoverclick').click(); // and now click to close
       expect($('.ls-popover').eq(0).hasClass('ls-active')).toEqual(false);
     });
 
-    it("Should trigger the event dropdown:closed when it closes by click", function() {
+    it("Should trigger the event popover:closed when it closes by click", function() {
       var id = $('.ls-popover').eq(0).attr("id");
-      var popoverToClose = "#" + id;
-      var spyEvent = spyOnEvent(popoverToClose, 'popover:closed');
-      $("#popoverclick").trigger("click");
-      $("#popoverclick").trigger("click");
-      expect('popover:closed').toHaveBeenTriggeredOn(popoverToClose);
+      var popoverToOpen = "#" + id;
+      var spyEvent = spyOnEvent(popoverToOpen, 'popover:closed');
+      $('#popoverclick').click(); // click to open
+      $('#popoverclick').click(); // and now click to close
+      expect('popover:closed').toHaveBeenTriggeredOn(popoverToOpen);
     });
 
+    // Hover Opening Popover
     it('Should show a popover on hover event', function() {
-      $('.ls-popover').hide();
       $('#popoverhover').trigger('mouseenter');
-      expect($('.ls-popover').eq(1).css('display')).toEqual("block");
+      expect($('.ls-popover').eq(1)).toHaveClass('ls-active');
     });
 
-    it("Should trigger the event dropdown:opened when it opens by mouseenter", function() {
+    it("Should trigger the event popover:opened when it opens by mouseenter", function() {
       var id = $('.ls-popover').eq(1).attr("id");
       var popoverToOpen = "#" + id;
       var spyEvent = spyOnEvent(popoverToOpen, 'popover:opened');
@@ -79,13 +69,11 @@ describe('Popover: ', function() {
     });
 
     it('Should close a popover on mouseleave event', function() {
-      $('.ls-popover').hide();
-      $('#popoverhover').trigger('mouseenter');
       $('#popoverhover').trigger('mouseleave');
-      expect($('.ls-popover').eq(1).css('display')).toEqual("none");
+      expect($('.ls-popover').eq(1).hasClass('ls-active')).toEqual(false);
     });
 
-    it("Should trigger the event dropdown:closed when it closes by mouseout", function() {
+    it("Should trigger the event popover:closed when it closes by mouseout", function() {
       var id = $('.ls-popover').eq(1).attr("id");
       var popoverToClose = "#" + id;
       var spyEvent = spyOnEvent(popoverToClose, 'popover:closed');
@@ -93,10 +81,9 @@ describe('Popover: ', function() {
       $('#popoverhover').trigger('mouseleave');
       expect('popover:closed').toHaveBeenTriggeredOn(popoverToClose);
     });
-
-
   });
 
+  // Testing Unbind
   describe('[unbind] When init is called multiple times', function () {
 
     it('should bind events on popover elements only one time', function () {
@@ -104,31 +91,12 @@ describe('Popover: ', function() {
       locastyle.init();
       locastyle.init();
       var $popoverTrigger = $('#popoverclick');
-      var $popover = $('#ls-popover-' + $popoverTrigger.data('uniqueId'));
+      var $popover = $('#ls-popover-' + $popoverTrigger.data('idPopover'));
       $popover.hide();
-      $popoverTrigger.trigger('click');
-      $popoverTrigger.trigger('click');
+      $popoverTrigger.click();
+      $popoverTrigger.click();
       expect( $popover ).not.toBeVisible();
     });
-  });
-
-  describe('change component on small screens', function () {
-    it('should not create a popover in small screens', function () {
-      locastyle.breakpointClass = 'ls-window-sm';
-      locastyle.popover.destroyPopover();
-      locastyle.popover.init();
-      var $popoverTrigger = $('#popoverclick');
-      var $popover = $('#ls-popover-' + $popoverTrigger.data('uniqueId'));
-      expect( $popover[0] ).toBeUndefined();
-    });
-
-    it('should open popover as modal in small screens', function () {
-      locastyle.breakpointClass = 'ls-window-sm';
-      locastyle.popover.init();
-      var $popoverTrigger = $('#popoverclick');
-      expect( $('.ls-modal') ).not.toBeUndefined();
-    });
-
   });
 
 });


### PR DESCRIPTION
- [x] Solve problems with destroy and initializer. Now, the destroy function remove all popovers of code and the Initializer just create popovers that was not created before.
- [x] Remove modal dependency
- [x] You can show one popover using the function `locastyle.popover.show(selector);
- [x] You can hide one popover using the function `locastyle.popover.hide(selector);

This don't have compatibility problem with popovers that already implemented in past versions of LocaStyle.