### PR TITLE
correção na classe .ls-no-spin

### DIFF
--- a/source/assets/stylesheets/locastyle/base/_helper-classes.sass
+++ b/source/assets/stylesheets/locastyle/base/_helper-classes.sass
@@ -257,6 +257,10 @@
 .ls-no-spin::-webkit-inner-spin-button
   -webkit-appearance: none
 
+.ls-no-spin
+  -moz-appearance: textfield
+  appearance: textfield
+
 // STYLES
 .ls-ellipsis
   overflow: hidden

--- a/source/documentacao/shared/form/_fields-prefix-sufix.erb
+++ b/source/documentacao/shared/form/_fields-prefix-sufix.erb
@@ -31,7 +31,7 @@
     <div class="row">
       <div class="ls-prefix-group col-md-4 col-sm-8 col-lg-3">
         <a href="" class="ls-label-text-prefix ls-bg-white">-</a>
-        <input type="text" value="8" class="ls-txt-center">
+        <input type="number" value="8" class="ls-txt-center ls-no-spin">
         <a href="" class="ls-label-text-prefix ls-bg-white">+</a>
       </div>
     </div>


### PR DESCRIPTION
Remove definitivamente as setinhas dos inputs type=number, nos navegadores, quando utilizada a classe: .ls-no-spin 

close #1560