### PR TITLE
Adicionando o atributo title aos items de menu

### DIFF
--- a/source/documentacao/exemplos/painel1/_sidebar.erb
+++ b/source/documentacao/exemplos/painel1/_sidebar.erb
@@ -15,11 +15,11 @@
 
       <nav class="ls-menu">
         <ul>
-           <li><a href="<%= base_url %>/documentacao/exemplos/painel1/home" class="ls-ico-dashboard">Dashboard</a></li>
-           <li><a href="<%= base_url %>/documentacao/exemplos/painel1/clients" class="ls-ico-users">Clientes</a></li>
-           <li><a href="<%= base_url %>/documentacao/exemplos/painel1/stats" class="ls-ico-stats">Relatórios da revenda</a></li>
+           <li><a href="<%= base_url %>/documentacao/exemplos/painel1/home" class="ls-ico-dashboard" title="Dashboard">Dashboard</a></li>
+           <li><a href="<%= base_url %>/documentacao/exemplos/painel1/clients" class="ls-ico-users" title="Clientes">Clientes</a></li>
+           <li><a href="<%= base_url %>/documentacao/exemplos/painel1/stats" class="ls-ico-stats" title="Relatórios da revenda">Relatórios da revenda</a></li>
            <li>
-            <a href="#" class="ls-ico-cog">Configurações</a>
+            <a href="#" class="ls-ico-cog" title="Configurações">Configurações</a>
             <ul>
               <li><a href="<%= base_url %>/documentacao/exemplos/painel1/config-domain">Domínios da Revenda</a></li>
               <li><a href="<%= base_url %>/documentacao/exemplos/painel1/config-email">E-mail de Remetente</a></li>

--- a/source/documentacao/exemplos/painel2/_sidebar.erb
+++ b/source/documentacao/exemplos/painel2/_sidebar.erb
@@ -7,10 +7,10 @@
       <a href="<%= base_url %>/documentacao/exemplos/<%= current_page.data.panel %>/pre-painel"  class="ls-go-prev"><span class="ls-text">Voltar à lista de serviços</span></a>
       <nav class="ls-menu">
         <ul>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel2/home" class="ls-ico-dashboard">Dashboard</a></li>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel2/stats" class="ls-ico-stats">Relatórios</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel2/home" class="ls-ico-dashboard" title="Dashboard">Dashboard</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel2/stats" class="ls-ico-stats" title="Relatórios">Relatórios</a></li>
           <li>
-            <a href="#" class="ls-ico-cog">Configurações</a>
+            <a href="#" class="ls-ico-cog" title="Configurações">Configurações</a>
             <ul>
               <li><a href="<%= base_url %>/documentacao/exemplos/painel2/config-server">Dados do Servidor SMTP</a></li>
               <li><a href="<%= base_url %>/documentacao/exemplos/painel2/config-email">E-mail de remetente</a></li>

--- a/source/documentacao/exemplos/painel3/_sidebar.erb
+++ b/source/documentacao/exemplos/painel3/_sidebar.erb
@@ -16,10 +16,10 @@
       <a href="<%= base_url %>/documentacao/exemplos/<%= current_page.data.panel %>/pre-painel"  class="ls-go-prev"><span class="ls-text">Voltar à lista de serviços</span></a>
       <nav class="ls-menu">
         <ul>
-        <li><a href="<%= base_url %>/documentacao/exemplos/painel3/nameservers" class="ls-ico-globe">Gerenciamento DNS</a></li>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel3/contacts" class="ls-ico-users">Contatos</a></li>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel3/transferout" class="ls-ico-cog">Transferência</a></li>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel3/transfer-international" class="ls-ico-cog">Transferência Internacional</a></li>
+        <li><a href="<%= base_url %>/documentacao/exemplos/painel3/nameservers" class="ls-ico-globe" title="Gerenciamento DNS">Gerenciamento DNS</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel3/contacts" class="ls-ico-users" title="Contatos">Contatos</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel3/transferout" class="ls-ico-cog" title="Transferência">Transferência</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel3/transfer-international" class="ls-ico-cog" title="Transferência Internacional">Transferência Internacional</a></li>
         </ul>
       </nav>
     </div>

--- a/source/documentacao/exemplos/painel4/_sidebar.erb
+++ b/source/documentacao/exemplos/painel4/_sidebar.erb
@@ -7,13 +7,13 @@
       <a href="<%= base_url %>/documentacao/exemplos/<%= current_page.data.panel %>/pre-painel"  class="ls-go-prev"><span class="ls-text">Voltar à lista de serviços</span></a>
       <nav class="ls-menu">
         <ul>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel4/home" class="ls-ico-home">Página inicial</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel4/home" class="ls-ico-home" title="Página inicial">Página inicial</a></li>
           <!-- <li><a href="<%= base_url %>/documentacao/exemplos/painel4/base" class="ls-ico-home">Primeiros passos</a></li> -->
-          <li><a href="#" class="ls-ico-screen">Meu Site</a></li>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel4/domains" class="ls-ico-link">Endereço do Site</a></li>
-          <li><a href="<%= base_url %>/documentacao/exemplos/painel4/plugins" class="ls-ico-attachment">Plugins</a></li>
+          <li><a href="#" class="ls-ico-screen" title="Meu Site">Meu Site</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel4/domains" class="ls-ico-link" title="Endereço do site">Endereço do Site</a></li>
+          <li><a href="<%= base_url %>/documentacao/exemplos/painel4/plugins" class="ls-ico-attachment" title="Plugins">Plugins</a></li>
           <li>
-            <a href="#" class="ls-ico-cog">Configurações</a>
+            <a href="#" class="ls-ico-cog" title="Configurações">Configurações</a>
             <ul>
               <li><a href="<%= base_url %>/documentacao/exemplos/painel4/config-language">Idiomas</a></li>
               <li><a href="<%= base_url %>/documentacao/exemplos/painel4/config-favicon">Favicon</a></li>

--- a/source/documentacao/exemplos/painel6/_sidebar.erb
+++ b/source/documentacao/exemplos/painel6/_sidebar.erb
@@ -19,9 +19,9 @@
       <h1 class="ls-brand-name ls-ico-earth"><%= link_to current_page.data.title_product, '../home' %></h1>
       <nav class="ls-menu">
         <ul>
-           <li><a href="<%= base_url %>/documentacao/exemplos/painel6/pre-painel" class="ls-ico-earth">Sites</a></li>
-           <li><a href="<%= base_url %>/documentacao/exemplos/painel6/clients" class="ls-ico-users">Consumo</a></li>
-           <li><a href="<%= base_url %>/documentacao/exemplos/painel6/stats" class="ls-ico-stats">Histórico</a></li>
+           <li><a href="<%= base_url %>/documentacao/exemplos/painel6/pre-painel" class="ls-ico-earth" title="Sites">Sites</a></li>
+           <li><a href="<%= base_url %>/documentacao/exemplos/painel6/clients" class="ls-ico-users" title="Consumo">Consumo</a></li>
+           <li><a href="<%= base_url %>/documentacao/exemplos/painel6/stats" class="ls-ico-stats" title="Histórico">Histórico</a></li>
         </ul>
       </nav>
     <% else %>


### PR DESCRIPTION
Depois de alguns testes com o tooltip e com a mesma solução que é aplicada no botão de voltar a lista de serviços, constatei que a melhor solução no momento é utilizar os atributos `title` em cada hyperlink, conforme o @deividmarques citou na issue #1512, pois para utilizar qualquer outra solução, necessitaríamos fazer uma boa refatoração da sidebar devido ao `overflow: hidden` aplicado em cada `li` e ao estilo de cada hyperlink interno.

Caso seja decido no futuro, podemos propor essa "refatoração" já prevendo esse cenário.

close #1512 