### PR TITLE
removing space between buttons tab when mobile

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_buttons.sass
+++ b/source/assets/stylesheets/locastyle/modules/_buttons.sass
@@ -118,6 +118,10 @@
       +single-transition(none)
       outline: none
 
+  .ls-form-inline &
+    [class*="ls-btn"] + [class*="ls-btn"]
+      margin-left: -1px
+
 //
 // Container that wraps the buttons in forms
 //


### PR DESCRIPTION
close issue #1580 

##### See print
![mobile-yes](https://cloud.githubusercontent.com/assets/1235904/9889713/321c62da-5bd2-11e5-9ff1-2fd793714ca7.png)

##### See also
http://localhost:4567/documentacao/exemplos/painel2/complaints