### PR TITLE
Correção dos links nos alertas

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_alerts.sass
+++ b/source/assets/stylesheets/locastyle/modules/_alerts.sass
@@ -15,11 +15,13 @@
     margin-bottom: 0
 
   a:not([class*="ls-btn"])
+    border-bottom-style: solid
+    border-bottom-width: 1px
     color: inherit
 
     &:hover,
     &:focus
-      text-decoration: underline
+      border-bottom: 0
 
   &.ls-md-space
     @extend .ls-md-space

--- a/source/assets/stylesheets/locastyle/modules/_alerts.sass
+++ b/source/assets/stylesheets/locastyle/modules/_alerts.sass
@@ -19,7 +19,7 @@
 
     &:hover,
     &:focus
-      text-decoration: none
+      text-decoration: underline
 
   &.ls-md-space
     @extend .ls-md-space

--- a/source/documentacao/shared/alerts/_alerts.erb
+++ b/source/documentacao/shared/alerts/_alerts.erb
@@ -1,4 +1,4 @@
 <div class="ls-alert-success"><strong>Sucesso!</strong> Você conseguiu, parabéns!</div>
 <div class="ls-alert-info"><strong>Atenção:</strong> Você tem informações importantes para ler.</div>
 <div class="ls-alert-warning"><strong>Cuidado:</strong> Cheque duas vezes. Você pode ter esquecido alguma informação.</div>
-<div class="ls-alert-danger"><strong>Vish!</strong> Algo muito ruim aconteceu e você vai precisar refazer tudo.</div>
+<div class="ls-alert-danger"><strong>Vish!</strong> Algo muito ruim aconteceu e você vai precisar refazer tudo. <a href="#">Clique aqui.</a></div>


### PR DESCRIPTION
De acordo com a discussão na issue #1586, os links dos alertas receberam o `border-bottom` como destaque natural e o mesmo é retirado nos estados `:hover` e `:focus`.

Close #1586 