### PR TITLE
Comportamento do hover de dropdown (danger link)

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_dropdown.sass
+++ b/source/assets/stylesheets/locastyle/modules/_dropdown.sass
@@ -37,6 +37,9 @@
         &:focus
           color: #fff !important
 
+      &.ls-color-danger:hover
+        background: $color-danger
+
   &.ls-active .ls-dropdown-nav
     display: block
 


### PR DESCRIPTION
O `:hover` dos links danger do dropdown foi modificado para utilizar sua cor original ($color-danger) no background.

Close #1593 