### PR TITLE
correção do estilo focus no dropdown com a classe ls-color-danger

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_dropdown.sass
+++ b/source/assets/stylesheets/locastyle/modules/_dropdown.sass
@@ -37,8 +37,11 @@
         &:focus
           color: #fff !important
 
-      &.ls-color-danger:hover
-        background: $color-danger
+      &.ls-color-danger
+        &:hover,
+        &:focus
+          background: $color-danger
+          color: #fff !important 
 
   &.ls-active .ls-dropdown-nav
     display: block


### PR DESCRIPTION
Deixando o estilo :focus igual ao :hover, quando existir a classe `.ls-color-danger`

close #1615 

![dropdown-okk](https://cloud.githubusercontent.com/assets/1235904/10590639/9f58ff38-7690-11e5-9bc1-51e7239a70d9.png)
