### PR TITLE
Popover position and arrow alignment

### DIFF
--- a/source/assets/javascripts/locastyle/_popover.js
+++ b/source/assets/javascripts/locastyle/_popover.js
@@ -99,7 +99,7 @@ locastyle.popover = (function() {
       case 'bottom':
         $(data.target).css({
           top : data.top  += (data.height + 12),
-          left: data.left += (data.width/2 + 4)
+          left: data.left += (data.width/2)
         });
         break;
       case 'left':
@@ -112,7 +112,7 @@ locastyle.popover = (function() {
       case 'top':
         $(data.target).css({
           top : data.top  -=  12,
-          left: data.left += (data.width/2 + 4)
+          left: data.left += (data.width/2)
         });
 
     }

--- a/source/assets/stylesheets/locastyle/modules/_popover.sass
+++ b/source/assets/stylesheets/locastyle/modules/_popover.sass
@@ -2,6 +2,9 @@ $arrowWidth: 10px
 $colorArrow: #fff
 $colorBorderPop: rgba(0, 0, 0, 0.2)
 
+%horizontal-position-calc
+  left: calc(50% - 10px)
+
 .ls-popover
   position: absolute
   z-index: 17
@@ -39,14 +42,14 @@ $colorBorderPop: rgba(0, 0, 0, 0.2)
 
   &.ls-popover-top
     &:after
+      @extend %horizontal-position-calc
       bottom: -$arrowWidth
-      left: calc(50% - 10px)
       border-width: $arrowWidth $arrowWidth 0 $arrowWidth
       border-color: $colorArrow transparent transparent transparent
 
     &:before
+      @extend %horizontal-position-calc
       bottom: -($arrowWidth + 1)
-      left: calc(50% - 10px)
       border-width: $arrowWidth $arrowWidth 0 $arrowWidth
       border-color: $colorBorderPop transparent transparent transparent
 
@@ -67,14 +70,14 @@ $colorBorderPop: rgba(0, 0, 0, 0.2)
 
   &.ls-popover-bottom
     &:after
+      @extend %horizontal-position-calc
       top: -$arrowWidth
-      left: calc(50% - 10px)
       border-width: 0 $arrowWidth $arrowWidth $arrowWidth
       border-color: transparent transparent #f7f7f7 transparent
 
     &:before
+      @extend %horizontal-position-calc
       top: -($arrowWidth + 1)
-      left: calc(50% - 10px)
       border-width: 0 $arrowWidth $arrowWidth $arrowWidth
       border-color: transparent transparent $colorBorderPop transparent
 

--- a/source/assets/stylesheets/locastyle/modules/_popover.sass
+++ b/source/assets/stylesheets/locastyle/modules/_popover.sass
@@ -40,15 +40,13 @@ $colorBorderPop: rgba(0, 0, 0, 0.2)
   &.ls-popover-top
     &:after
       bottom: -$arrowWidth
-      left: 46.5%
-      margin-left: -8px
+      left: calc(50% - 10px)
       border-width: $arrowWidth $arrowWidth 0 $arrowWidth
       border-color: $colorArrow transparent transparent transparent
 
     &:before
       bottom: -($arrowWidth + 1)
-      left: 46.5%
-      margin-left: -8px
+      left: calc(50% - 10px)
       border-width: $arrowWidth $arrowWidth 0 $arrowWidth
       border-color: $colorBorderPop transparent transparent transparent
 
@@ -70,13 +68,13 @@ $colorBorderPop: rgba(0, 0, 0, 0.2)
   &.ls-popover-bottom
     &:after
       top: -$arrowWidth
-      left: 46.5%
+      left: calc(50% - 10px)
       border-width: 0 $arrowWidth $arrowWidth $arrowWidth
       border-color: transparent transparent #f7f7f7 transparent
 
     &:before
       top: -($arrowWidth + 1)
-      left: 46.5%
+      left: calc(50% - 10px)
       border-width: 0 $arrowWidth $arrowWidth $arrowWidth
       border-color: transparent transparent $colorBorderPop transparent
 

--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -71,7 +71,6 @@ type: component
 
   <div class="ls-box-demo">
     <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="top" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página"></a>
-    <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="bottom" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página"></a>
     <br>
     <br>
     <a href="#" class="ls-btn-primary" data-ls-module="popover" data-placement="right" data-ls-popover="open" data-title="Titulo do popover" data-content="<ul class='ls-no-list-style'>

--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -71,6 +71,7 @@ type: component
 
   <div class="ls-box-demo">
     <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="top" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página"></a>
+    <a href="#" class="ls-ico-help" data-ls-popover="open" data-placement="bottom" data-ls-module="popover" title="Titulo" data-content="Exemplo de popover Aberto, <br> ao carregar a página"></a>
     <br>
     <br>
     <a href="#" class="ls-btn-primary" data-ls-module="popover" data-placement="right" data-ls-popover="open" data-title="Titulo do popover" data-content="<ul class='ls-no-list-style'>


### PR DESCRIPTION
I changed the calc of popover (top and bottom) position and arrow alignment to works better.

It was necessary to remove the +4 sum from left position on JS file, because the `$(popoverTrigger).outerWidth()` return the necessary value to calc the position, including the border.

In the CSS file a simple calc using the 50% width of the popover minus 10px (half arrow width) resolved the problem. 

Close #1596.