### PR TITLE
Improvements animations for a better performance.

### DIFF
--- a/source/assets/stylesheets/locastyle/base/_animate.sass
+++ b/source/assets/stylesheets/locastyle/base/_animate.sass
@@ -11,28 +11,27 @@
 @-webkit-keyframes fadeInUp
   0%
     opacity: 0
-    -webkit-transform: translateY(20px)
+
+    -webkit-transform: translate3d(0,20px,0)
   100%
     opacity: 1
-    -webkit-transform: translateY(0)
-
+    -webkit-transform: translate3d(0,0,0)
 
 @-moz-keyframes fadeInUp
   0%
     opacity: 0
-    -moz-transform: translateY(20px)
+    -moz-transform: translate3d(0,20px,0)
   100%
     opacity: 1
-    -moz-transform: translateY(0)
+    -moz-transform: translate3d(0,0,0)
 
 @keyframes fadeInUp
   0%
     opacity: 0
-    transform: translateY(20px)
+    transform: translate3d(0,20px,0)
   100%
     opacity: 1
-    transform: translateY(0)
-
+    transform: translate3d(0,0,0)
 
 .fade-in-up
   -webkit-animation-name: fadeInUp
@@ -42,38 +41,26 @@
 @-webkit-keyframes fadeInDown
   0%
     opacity: 0
-    -webkit-transform: translateY(-20px)
+    -webkit-transform: translate3d(0,-20px,0)
   100%
     opacity: 1
-    -webkit-transform: translateY(0)
-
+    -webkit-transform: translate3d(0,0,0)
 
 @-moz-keyframes fadeInDown
   0%
     opacity: 0
-    -moz-transform: translateY(-20px)
+    -moz-transform: translate3d(0,-20px,0)
   100%
     opacity: 1
-    -moz-transform: translateY(0)
-
-
-@-o-keyframes fadeInDown
-  0%
-    opacity: 0
-    -ms-transform: translateY(-20px)
-  100%
-    opacity: 1
-    -ms-transform: translateY(0)
-
+    -moz-transform: translate3d(0,0,0)
 
 @keyframes fadeInDown
   0%
     opacity: 0
-    transform: translateY(-20px)
+    transform: translate3d(0,-20px,0)
   100%
     opacity: 1
-    transform: translateY(0)
-
+    transform: translate3d(0,0,0)
 
 .fade-in-down
   -webkit-animation-name: fadeInDown
@@ -83,38 +70,26 @@
 @-webkit-keyframes fadeInRight
   0%
     opacity: 0
-    -webkit-transform: translateX(-20px)
+    -webkit-transform: translate3d(-20px,0,0)
   100%
     opacity: 1
-    -webkit-transform: translateX(0)
-
+    -webkit-transform: translate3d(0,0,0)
 
 @-moz-keyframes fadeInRight
   0%
     opacity: 0
-    -moz-transform: translateX(-20px)
+    -moz-transform: translate3d(-20px,0,0)
   100%
     opacity: 1
-    -moz-transform: translateX(0)
-
-
-@-o-keyframes fadeInRight
-  0%
-    opacity: 0
-    -o-transform: translateX(-20px)
-  100%
-    opacity: 1
-    -o-transform: translateX(0)
-
+    -moz-transform: translate3d(0,0,0)
 
 @keyframes fadeInRight
   0%
     opacity: 0
-    transform: translateX(-20px)
+    transform: translate3d(-20px,0,0)
   100%
     opacity: 1
-    transform: translateX(0)
-
+    transform: translate3d(0,0,0)
 
 .fade-in-right
   -webkit-animation-name: fadeInRight
@@ -124,28 +99,26 @@
 @-webkit-keyframes fadeInLeft
   0%
     opacity: 0
-    -webkit-transform: translateX(20px)
+    -webkit-transform: translate3d(20px,0,0)
   100%
     opacity: 1
-    -webkit-transform: translateX(0)
-
+    -webkit-transform: translate3d(0,0,0)
 
 @-moz-keyframes fadeInLeft
   0%
     opacity: 0
-    -moz-transform: translateX(20px)
+    -moz-transform: translate3d(20px,0,0)
   100%
     opacity: 1
-    -moz-transform: translateX(0)
+    -moz-transform: translate3d(0,0,0)
 
 @keyframes fadeInLeft
   0%
     opacity: 0
-    transform: translateX(20px)
+    transform: translate3d(20px,0,0)
   100%
     opacity: 1
-    transform: translateX(0)
-
+    transform: translate3d(0,0,0)
 
 .fade-in-left
   -webkit-animation-name: fadeInLeft


### PR DESCRIPTION
So ... I changed the attribute ```translateX``` and ```translateY``` for ```translate3d``` to improvement the performance.

The ```translate3d``` use a CSS3 Hardware acceleration, and this is better to animation performance, I recommend always use the ```translate3d``` instead X and Y.

I also remove the ```@-o-keyframes``` because the Opera browser uses webkit a longer time.