### PR TITLE
Update jasmine to 2.4.0 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'eco'
 gem 'compass', '~> 1.0.0.alpha.19'
 gem 'sass', '~> 3.3.9'
 
-gem 'jasmine', '~> 2.2.0'
+gem 'jasmine', '~> 2.4.0'
 gem 'jshint_on_rails'
 
 gem 'therubyracer' # faster JS compiles

--- a/spec/javascripts/steps_spec.js
+++ b/spec/javascripts/steps_spec.js
@@ -147,7 +147,7 @@ describe("Steps: ", function(){
     });
   });
 
-  describe('prevStep', function(argument){
+  describe('prevStep', function(){
     it("checks the active list and adds in the prev ls-active class", function(){
       locastyle.steps.prevStep();
       expect($('#list1').hasClass('ls-active')).toBe(true);


### PR DESCRIPTION
Because travis used this version and it  was breaking a test and with it all PRs also broke the travis.

![travis](https://cloud.githubusercontent.com/assets/1235904/11753385/009ed032-a02c-11e5-818d-78ad33e268fa.png)
