### PR TITLE
Fix infinite loop timeout to change breakpoint classes on resize

### DIFF
--- a/source/assets/javascripts/locastyle/_breakpoint-check.js
+++ b/source/assets/javascripts/locastyle/_breakpoint-check.js
@@ -27,7 +27,7 @@ locastyle.breakpoints = (function() {
   function breakpointWindowWidth(userConfig) {
     var documentWidth;
 
-    if (userConfig){
+    if (userConfig) {
       documentWidth = userConfig.documentWidth;
     } else {
       documentWidth = $(document).width();
@@ -36,25 +36,25 @@ locastyle.breakpoints = (function() {
     // If less than 768 - xs
     if (documentWidth < config.sm) {
       config.html.addClass('ls-window-xs');
-      locastyle.breakpointClass = "ls-window-xs";
+      locastyle.breakpointClass = 'ls-window-xs';
     }
 
     // If greater than or equal to 768 and less than 992 - sm
     else if (documentWidth >= config.sm && documentWidth < config.md) {
       config.html.addClass('ls-window-sm').removeClass('ls-sidebar-visible ls-notifications-visible ');
-      locastyle.breakpointClass = "ls-window-sm";
+      locastyle.breakpointClass = 'ls-window-sm';
     }
 
     // If greater than or equal to 992 and less than 1200 - md
     else if (documentWidth >= config.md && documentWidth < config.lg) {
       config.html.addClass('ls-window-md').removeClass('ls-sidebar-visible ls-notifications-visible ');
-      locastyle.breakpointClass = "ls-window-md";
+      locastyle.breakpointClass = 'ls-window-md';
     }
 
     // If greater than or equal to 1200 - lg
     else {
       config.html.addClass('ls-window-lg').removeClass('ls-sidebar-visible ls-notifications-visible ');
-      locastyle.breakpointClass = "ls-window-lg";
+      locastyle.breakpointClass = 'ls-window-lg';
     }
   }
 
@@ -63,7 +63,7 @@ locastyle.breakpoints = (function() {
   //
   function breakpointScreenWidth(userConfig) {
     var screenWidth;
-    
+
     if (userConfig){
       screenWidth = userConfig.documentWidth;
     } else {
@@ -73,25 +73,25 @@ locastyle.breakpoints = (function() {
     // If less than 768 - xs
     if (screenWidth < config.sm) {
       config.html.addClass('ls-screen-xs');
-      locastyle.breakpointScreenClass = "ls-screen-xs";
+      locastyle.breakpointScreenClass = 'ls-screen-xs';
     }
 
     // If greater than or equal to 768 and less than 992 - sm
     else if (screenWidth >= config.sm && screenWidth < config.md) {
       config.html.addClass('ls-screen-sm');
-      locastyle.breakpointScreenClass = "ls-screen-sm";
+      locastyle.breakpointScreenClass = 'ls-screen-sm';
     }
 
     // If greater than or equal to 992 and less than 1200 - md
     else if (screenWidth >= config.md && screenWidth < config.lg) {
       config.html.addClass('ls-screen-md');
-      locastyle.breakpointScreenClass = "ls-screen-md";
+      locastyle.breakpointScreenClass = 'ls-screen-md';
     }
 
     // If greater than or equal to 1200 - lg
     else {
       config.html.addClass('ls-screen-lg');
-      locastyle.breakpointScreenClass = "ls-screen-lg";
+      locastyle.breakpointScreenClass = 'ls-screen-lg';
     }
   }
 
@@ -99,14 +99,11 @@ locastyle.breakpoints = (function() {
   // Changing the class in html tag when resized the window.
   //
   function changeClassBreakpoint() {
-
     var changeClass;
-
-    $(window).resize(function() {
+    $(window).on('resize', function() {
       clearTimeout(changeClass);
 
       changeClass = setTimeout(function() {
-
         var breakpointActive = config.html.attr('class').replace(/(^|\s)(ls-window-\S+)|(ls-screen-\S+)/g, '');
 
         config.html.attr('class', $.trim(breakpointActive));
@@ -115,7 +112,7 @@ locastyle.breakpoints = (function() {
         breakpointScreenWidth();
 
         // event triggers to inform other modules that the breakpoint has been updated
-        $.event.trigger("breakpoint-updated");
+        $.event.trigger('breakpoint-updated');
         clearTimeout(changeClass);
       }, 300);
     });

--- a/source/assets/javascripts/locastyle/_breakpoint-check.js
+++ b/source/assets/javascripts/locastyle/_breakpoint-check.js
@@ -116,8 +116,8 @@ locastyle.breakpoints = (function() {
 
         // event triggers to inform other modules that the breakpoint has been updated
         $.event.trigger("breakpoint-updated");
+        clearTimeout(changeClass);
       }, 300);
-
     });
   }
 


### PR DESCRIPTION
I want to resolve #1641 

I really do not have an idea about what I did is a better way to do this, so, help me!
What I did? So ... I put the ```clearTimeout``` inside of ```setTimeout```.

Before I do this, I Google it to make sure if do this is good or no.

All I found was saying something like: "You can do this to have sure to stop your timeout, but you should try to make it better next time, okay?"

What do you think?

When we make a resize the method enters a infinite loop, but, right now, the method pass 2 times.

See the issue #1641 

