### PR TITLE
Redirect doc root to intro

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -96,7 +96,7 @@ activate :directory_indexes
 activate :i18n
 
 #Redirect
-redirect "documentacao/index.html", to: "documentacao/introducao"
+redirect "documentacao/index.html", to: "/documentacao/introducao"
 
 # Build-specific configuration
 configure :build do

--- a/config.rb
+++ b/config.rb
@@ -95,6 +95,9 @@ set :images_dir, 'assets/images'
 activate :directory_indexes
 activate :i18n
 
+#Redirect
+redirect "documentacao/index.html", to: "documentacao/introducao"
+
 # Build-specific configuration
 configure :build do
   # For example, change the Compass output style for deployment

--- a/source/documentacao/index.html.erb
+++ b/source/documentacao/index.html.erb
@@ -4,4 +4,6 @@ layout: mobile
 description: Use direto dos nossos servidores ou baixe uma versão estável para incorporar em seu projeto ou usar offline.
 ---
 
-<%= partial 'documentacao/shared/passo-a-passo/passo' %>
+<script>
+  window.location.href = '/documentacao/introducao/';
+</script>

--- a/source/documentacao/index.html.erb
+++ b/source/documentacao/index.html.erb
@@ -4,6 +4,4 @@ layout: mobile
 description: Use direto dos nossos servidores ou baixe uma versão estável para incorporar em seu projeto ou usar offline.
 ---
 
-<script>
-  window.location.href = '/documentacao/introducao/';
-</script>
+<%= partial 'documentacao/shared/passo-a-passo/passo' %>

--- a/source/documentacao/index.html.erb
+++ b/source/documentacao/index.html.erb
@@ -3,5 +3,3 @@ title: Documentação
 layout: mobile
 description: Use direto dos nossos servidores ou baixe uma versão estável para incorporar em seu projeto ou usar offline.
 ---
-
-<%= partial 'documentacao/shared/passo-a-passo/passo' %>


### PR DESCRIPTION
Redirect the documentation root folder to introduction.
I tried some solutions using Middleman configs but I had no success. So the easier solution was use the javascript `window.location.href` to avoid the user to access the `/documentacao/`.

close #1625