### PR TITLE
Data blocked modal bug fix

### DIFF
--- a/source/assets/javascripts/locastyle/_modal.js
+++ b/source/assets/javascripts/locastyle/_modal.js
@@ -103,7 +103,7 @@ locastyle.modal = (function() {
     var target = $(el).data('target') ? $(el.data('target')) : $(el);
     target.each(function(i,e){
       if ($(e).data('modal-blocked') !== undefined) {
-        $('[data-dismiss="modal"]').remove();
+        $(e).find('[data-dismiss="modal"]').remove();
       } else {
         bindClose();
       }


### PR DESCRIPTION
Change the jQuery selector to remove only the `data-dismiss` elements inside the `data-modal-blocked` element.

Close #1630 