### PR TITLE
Title intro button variation

### DIFF
--- a/source/assets/stylesheets/locastyle/base/_typography.sass
+++ b/source/assets/stylesheets/locastyle/base/_typography.sass
@@ -56,6 +56,14 @@ p
   border-bottom: 1px solid
   +rgba(border-bottom-color,$gray1,.4)
 
+  [class*="ls-btn"]
+    float: right
+    margin-top: 2px !important
+
+  .ls-text-title
+    width: 50%
+    @extend .ls-ellipsis
+
   &.ls-no-bg
     border-bottom: none
     margin-bottom: 0
@@ -151,8 +159,10 @@ p
     font-size: remtopx(2.25)
     font-weight: 300
 
-    &[class*="ls-ico"]
+    .ls-text-title
+      width: 70%
 
+    &[class*="ls-ico"]
       &:before
         margin-left: 0
         margin-right: 10px


### PR DESCRIPTION
The title intro variation with a button inside uses a new structure to avoid long texts to break the layout. Use a `<span>` with a new `.ls-text-title` class was a good solution. The image below illustrate the usage.

![screen shot 2016-02-26 at 12 06 23 pm](https://cloud.githubusercontent.com/assets/5097397/13356169/d8ee1b4a-dc82-11e5-9a29-812e6cec9ec5.png)

The best way the test this PR is create the same title structure in a example painel. In the future the email marketing team will release the entire panel example on the documentation.

close #1657 