### PR TITLE
Change the .ls-custom-select width

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_custom-fields.sass
+++ b/source/assets/stylesheets/locastyle/modules/_custom-fields.sass
@@ -11,7 +11,7 @@
   overflow: hidden
   vertical-align: middle
   height: $input-height
-  width: 98%
+  width: 100%
 
   .ls-box-filter &
     width: 100%


### PR DESCRIPTION
Apparently there's no reason to this `width: 98%` on the `.ls-custom-select`.

close #1656 