### PR TITLE
Inline text for forms

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -402,6 +402,14 @@ input + .ls-label-text-prefix
     .ls-label
       margin-bottom: 15px
 
+  .ls-form-horizontal,
+  .ls-form-inline
+    .ls-inline-text
+      display: none
+
+      & + [class*="ls-btn"]
+        display: none
+
 @media screen and (min-width: $screen-md)
   .ls-form-inline
 

--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -39,7 +39,7 @@
       font-size: 11px
       padding-bottom: 5px
       margin-bottom: 0
- 
+
   b ~ label
     font-weight: normal
 
@@ -342,6 +342,18 @@ input + .ls-label-text-prefix
   left: -4px
   z-index: 2
 
+////
+// Inline Text
+////
+.ls-form-horizontal,
+.ls-form-inline
+  .ls-inline-text
+    display: inline-block
+    margin-top: 7px
+
+    & + [class*="ls-btn"]
+      margin-left: 26px
+
 @media screen and (max-width: $screen-sm)
 
   .ls-form-horizontal
@@ -406,6 +418,6 @@ input + .ls-label-text-prefix
 @media screen and (min-width: $screen-sm) and(max-width: $screen-md)
 
   .ls-box-filter
-    .ls-form-inline.ls-float-left 
+    .ls-form-inline.ls-float-left
       .ls-label
-        margin-bottom: 0 
+        margin-bottom: 0

--- a/source/documentacao/formularios/index.html.erb
+++ b/source/documentacao/formularios/index.html.erb
@@ -69,4 +69,29 @@ type: forms
     </p>
   </div>
 
+  <hr>
+  <h3 class="doc-title-3">Texto inline nos forms</h3>
+  <p>Textos inlines podem ser aplicados nos forms utilizando a classe <code>ls-inline-text</code>. Sua aplicação depende da separação dos elementos em colunas para que o texto fique verticalmente alinhado com o campo. Abaixo seguem os exemplos de utilização com os formulários inline e horizontal.</p>
+
+  <h5 class="doc-title-5">Form inline</h5>
+  <p>Na utilização inline, não é necessário fazer nenhuma modificação na sua aplicação normal.</p>
+
+  <div class="ls-box-demo">
+    <%= partial 'documentacao/shared/form/form-inline-text.erb' %>
+  </div>
+  <% code("html") do %><%= partial 'documentacao/shared/form/form-inline-text.erb' %><% end %>
+
+  <h5 class="doc-title-5">Form horizontal</h5>
+  <p>No caso da aplicação nos forms horizontais, o <code>label</code> deve ficar separado das colunas de referência para que o alinhamento vertical seja mantido, conforme o exemplo abaixo:</p>
+
+  <div class="ls-box-demo">
+    <%= partial 'documentacao/shared/form/form-horizontal-text.erb' %>
+  </div>
+  <% code("html") do %><%= partial 'documentacao/shared/form/form-horizontal-text.erb' %><% end %>
+
+  <div class="ls-box ls-box-gray">
+    <h4>Observação</h4>
+    <p>As colunas de referências devem conter somente os elementos que devem ser alinhar verticalmente, no caso dos exemplos, input, texto e botão.</p>
+  </div>
+
 </section>

--- a/source/documentacao/shared/form/_form-horizontal-text.erb
+++ b/source/documentacao/shared/form/_form-horizontal-text.erb
@@ -1,0 +1,14 @@
+<form class="ls-form ls-form-horizontal">
+  <label class="ls-label ls-no-margin-bottom col-md-12">
+    <b class="ls-label-text" for="emails-list">Adicionar um e-mail</b>
+  </label>
+
+  <div class="ls-label col-md-6">
+    <input type="email" placeholder="E-mail">
+  </div>
+
+  <div class="col-md-6">
+    <span class="ls-inline-text">ou</span>
+    <a href="#" class="ls-btn-primary ls-no-margin-top">Novo E-mail</a>
+  </div>
+</form>

--- a/source/documentacao/shared/form/_form-horizontal.erb
+++ b/source/documentacao/shared/form/_form-horizontal.erb
@@ -11,13 +11,9 @@
       <b class="ls-label-text">Nome</b>
       <input type="text" name="nome" placeholder="Primeiro nome" class="ls-field" required>
     </label>
-    <label class="ls-label col-md-4 col-xs-12">
-      <b class="ls-label-text">Sobrenome</b>
-      <input type="text" name="nome" placeholder="Sobrenome" class="ls-field" required>
-    </label>
   </fieldset>
 
-    <hr>
+  <hr>
 
   <fieldset>
     <!-- Exemplo com Checkbox -->
@@ -42,7 +38,8 @@
     </div>
   </fieldset>
 
-    <hr>
+  <hr>
+
   <fieldset>
     <!-- Exemplo com Radio button -->
     <div class="ls-label col-md-12">

--- a/source/documentacao/shared/form/_form-inline-text.erb
+++ b/source/documentacao/shared/form/_form-inline-text.erb
@@ -1,0 +1,11 @@
+<form class="ls-form ls-form-inline">
+  <label class="ls-label col-md-4">
+    <b class="ls-label-text">E-mail</b>
+    <input type="text" name="email" placeholder="Escreva seu email" required >
+  </label>
+
+  <div class="col-md-6">
+    <span class="ls-inline-text">ou</span>
+    <a href="#" class="ls-btn-danger">Cancelar</a>
+  </div>
+</form>


### PR DESCRIPTION
This variation is a little bit hard to implement not using the bootstrap columns because or width inputs are 100% with their parent element.

Close #1654 