### PR TITLE
Modificação no redirecionamento da documentação

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -96,7 +96,7 @@ activate :directory_indexes
 activate :i18n
 
 #Redirect
-redirect "documentacao/index.html", to: "/documentacao/introducao"
+#redirect "documentacao/index.html", to: "/documentacao/introducao"
 
 # Build-specific configuration
 configure :build do

--- a/source/documentacao/index.html.erb
+++ b/source/documentacao/index.html.erb
@@ -3,3 +3,7 @@ title: Documentação
 layout: mobile
 description: Use direto dos nossos servidores ou baixe uma versão estável para incorporar em seu projeto ou usar offline.
 ---
+
+<script>
+  window.location.href = '/documentacao/introducao'
+</script>


### PR DESCRIPTION
O redirecionamento de `/documentacao` para `/documentacao/introducao` foi modificado pelo erro que o Middleman apresenta na hora de gerar o build do projeto. Esse erro foi corrigido na V4 do Middleman. 

Decidimos temporariamente manter a solução JS, que também resolve o problema, antes de pensarmos em uma atualização do Middleman no projeto.