### PR TITLE
Correção do Textarea Auto Resize

### DIFF
--- a/source/assets/javascripts/locastyle/_form.js
+++ b/source/assets/javascripts/locastyle/_form.js
@@ -50,7 +50,7 @@ locastyle.form = (function() {
   }
 
   function textareaHeight (){
-    $('textarea').each(function (index, textarea) {
+    $('textarea.ls-textarea-autoresize', '.ls-label').each(function (index, textarea) {
       var text = $(textarea).val();
       var lines = text.split(/\r|\r\n|\n/);
       var count = lines.length;

--- a/spec/javascripts/fixtures/forms_fixture.html
+++ b/spec/javascripts/fixtures/forms_fixture.html
@@ -1,13 +1,20 @@
-<div id="mypassword">
-  <input type="password" maxlength="20" id="password_field" name="password" value="locastyle é da hora né?" >
-  <a class="ls-toggle-pass" data-target="#password_field" href="#">alterar</a>
-</div>
+<form class="ls-form" data-ls-module="form">
+  <div id="mypassword">
+    <input type="password" maxlength="20" id="password_field" name="password" value="locastyle é da hora né?" >
+    <a class="ls-toggle-pass" data-target="#password_field" href="#">alterar</a>
+  </div>
 
-<div id="mytypetext">
-  <input type="text" maxlength="20" id="password_field2" name="password" value="locastyle é da hora né?" >
-  <a class="ls-toggle-pass" data-target="#password_field2" href="#">alterar</a>
-</div>
+  <div id="mytypetext">
+    <input type="text" maxlength="20" id="password_field2" name="password" value="locastyle é da hora né?" >
+    <a class="ls-toggle-pass" data-target="#password_field2" href="#">alterar</a>
+  </div>
 
-<a id="changeClass" class="ls-toggle-pass" data-toggle-class="my-new-class, my-old-class" data-target="#password_field2" href="#">alterar</a>
+  <a id="changeClass" class="ls-toggle-pass" data-toggle-class="my-new-class, my-old-class" data-target="#password_field2" href="#">alterar</a>
 
-<textarea name="" id="" cols="30" rows="1">com Fulano de Tal no telefone: 11 5555-5555. </textarea>
+  <label class="ls-label">
+    <textarea class="ls-textarea-autoresize" name="" id="" cols="30" rows="1">
+      Com Fulano de Tal,
+      no telefone: 11 5555-5555.
+    </textarea>
+  </label>
+</form>

--- a/spec/javascripts/form_spec.js
+++ b/spec/javascripts/form_spec.js
@@ -24,7 +24,7 @@ describe("Forms: ", function() {
 
   describe("When exist textarea", function(){
     it("textarea has atribute height", function(){
-      expect($("textarea")).toHaveCss({ height: "18px" });
+      expect($("textarea")).toHaveCss({ height: "54px" });
     });
   });
 


### PR DESCRIPTION
A função que calcula a altura da textarea estava com o seletor abrangente para todas as textareas, fazendo com que o atributo `row` ficasse inutilizável dentro de qualquer contexto.

close #1646 