### PR TITLE
Removendo transitionend pra evitar múltiplas chamadas no trigger do resize

### DIFF
--- a/source/assets/javascripts/docs/panel-charts.js
+++ b/source/assets/javascripts/docs/panel-charts.js
@@ -1,7 +1,7 @@
 $(function () {
 
   // This will resize all charts examples on sidebar minimize or maximize
-  $(document).on('sidebar-minimize sidebar-maximize transitionend', function() {
+  $(document).on('sidebar-minimize sidebar-maximize', function() {
     $(window).resize();
   });
 

--- a/source/assets/javascripts/locastyle/_sidebar-toggle.js
+++ b/source/assets/javascripts/locastyle/_sidebar-toggle.js
@@ -8,7 +8,6 @@ locastyle.sidebarToggle = (function() {
     checkStatus();
     addArrowToggle();
     sidebarToggling();
-    checkStatus();
     maximizeMobile();
   }
 


### PR DESCRIPTION
O transitionend chamava sempre o resize que por sua vez, estava impactando outros métodos que funcionam sempre que o resize é chamado e com isso acontecia vários erros. (abaixo temos alguns gif pra exemplificar).

Ele ativada o resize até mesmo no hover dos botões (já que o mesmo recebe o transition de cores via css)

close #1665

_Essa correção foi feita com a ajuda do @palloi_ 

#### Atualmente não conseguimos clicar no dropdown quando estiver em mobile

**print do erro**
![error](https://cloud.githubusercontent.com/assets/1235904/13830949/00bbd258-ebaf-11e5-8d8f-0f9937bcd7e5.gif)

**print da correção**
![ok](https://cloud.githubusercontent.com/assets/1235904/13830974/2bde046a-ebaf-11e5-9a09-7a8f360b1a22.gif)


#### Adicionei um console.log  no método changeClassBreakpoint() pra exemplificar melhor o erro

![example-error](https://cloud.githubusercontent.com/assets/1235904/13831042/870a1d74-ebaf-11e5-8903-041cb1bdb3d5.gif)

#### Com a correção o console.log (adicionado pra exemplificar) não é mais exibido

![example-ok](https://cloud.githubusercontent.com/assets/1235904/13831083/c4817224-ebaf-11e5-87ee-a6fbfcd7cc67.gif)