### PR TITLE
Correção nos tamanhos dos campos de input com prefixos e sufixo

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_buttons.sass
+++ b/source/assets/stylesheets/locastyle/modules/_buttons.sass
@@ -169,6 +169,7 @@
   .ls-form-horizontal &
     @extend .ls-clearfix
     padding-top: 21px
+    clear: both
 
     [class*="ls-btn"]:not(.ls-btn-block)
       @extend .ls-no-margin-top

--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -277,6 +277,9 @@ input.ls-form-text,
     border-left: none !important
     padding-left: 8px !important
 
+  .ls-table &
+    border-collapse: initial
+
 .ls-middle-label
   display: inline-block
   padding-top: 9px
@@ -351,12 +354,18 @@ input.ls-form-text,
   border-bottom-left-radius: 0
   border-top-left-radius: 0
 
+  .ls-table & 
+    margin-left: -2px
+
 input + .ls-label-text-prefix
   border: 1px solid $gray2
   border-radius: 0 $default-radius $default-radius 0
   position: relative
   left: -4px
   z-index: 2
+
+  .ls-table & 
+    left: -6px
 
 @media screen and (max-width: $screen-sm)
 

--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -286,7 +286,7 @@ input.ls-form-text,
 //
 .ls-prefix-group
   position: relative
-  height: 36px
+  height: $input-height
   display: table
 
   .ls-form-inline &
@@ -305,6 +305,22 @@ input.ls-form-text,
     height: inherit
     margin-bottom: 0
     display: table-cell
+
+  &.ls-field-lg
+    height: $input-lg-height
+
+  &.ls-field-sm
+    height: $input-sm-height
+
+  &.ls-field-xs
+    height: $input-xs-height
+
+    .ls-label-text-prefix
+      font-size: 12px
+      padding: 4px 12px
+
+    input
+      height: $input-xs-height 
 
 .ls-label-text-prefix
   width: 1%

--- a/source/documentacao/formularios/tamanho-dos-campos.html.erb
+++ b/source/documentacao/formularios/tamanho-dos-campos.html.erb
@@ -132,10 +132,6 @@ description: Aumente ou diminua o tamanho dos campos de formulários
 
   <h2 class="doc-title-3">Alterando altura dos campos com prefixos e sufixos</h2>
   <p>Para alterar a altura dos prefixos e sufixos, basta adicionar as classes abaixo na classe <code>.ls-prefix-group</code> <br>
-  <code>.ls-field-lg</code> (grande), <br>
-  <code>.ls-field-md</code> (tamanho default), <br>
-  <code>.ls-field-sm</code> (pequeno), <br>
-  <code>.ls-field-xs</code> (muito pequeno)</p>
 
   <table class="ls-table">
     <thead>
@@ -148,8 +144,43 @@ description: Aumente ou diminua o tamanho dos campos de formulários
       <tr>
         <td>ls-field-lg</td>
         <td>
-          <label class="ls-label col-md-12 col-xs-12">
+          <label class="ls-label col-md-12 col-xs-102">
             <div class="ls-prefix-group ls-field-lg">
+              <span class="ls-label-text-prefix">URL</span>
+              <input type="text" name="nome" required >
+              <span class="ls-label-text-prefix">.com.br</span>
+            </div>
+          </label>
+        </td>
+      </tr>
+      <tr>
+        <td>ls-field-md (tamanho default)</td>
+        <td>
+          <label class="ls-label col-md-12 col-xs-12">
+            <div class="ls-prefix-group ls-field-md">
+              <!-- <span class="ls-label-text-prefix">URL</span> -->
+              <input type="text" name="nome" required >
+              <span class="ls-label-text-prefix">.subdominio.com.br</span>
+            </div>
+          </label>
+        </td>
+      </tr>
+      <tr>
+        <td>ls-field-sm</td>
+        <td>
+          <label class="ls-label col-md-12 col-xs-12">
+            <div class="ls-prefix-group ls-field-sm">
+              <span class="ls-label-text-prefix">URL</span>
+              <input type="text" name="nome" required >
+            </div>
+          </label>
+        </td>
+      </tr>
+      <tr>
+        <td>ls-field-xs</td>
+        <td>
+          <label class="ls-label col-md-12 col-xs-12">
+            <div class="ls-prefix-group ls-field-xs">
               <span class="ls-label-text-prefix">URL</span>
               <input type="text" name="nome" required >
             </div>

--- a/source/documentacao/formularios/tamanho-dos-campos.html.erb
+++ b/source/documentacao/formularios/tamanho-dos-campos.html.erb
@@ -130,4 +130,42 @@ description: Aumente ou diminua o tamanho dos campos de formulários
     </tbody>
   </table>
 
+  <h2 class="doc-title-3">Alterando altura dos campos com prefixos e sufixos</h2>
+  <p>Para alterar a altura dos prefixos e sufixos, basta adicionar as classes abaixo na classe <code>.ls-prefix-group</code> <br>
+  <code>.ls-field-lg</code> (grande), <br>
+  <code>.ls-field-md</code> (tamanho default), <br>
+  <code>.ls-field-sm</code> (pequeno), <br>
+  <code>.ls-field-xs</code> (muito pequeno)</p>
+
+  <table class="ls-table">
+    <thead>
+      <tr>
+        <th>Nome</th>
+        <th>Resultado</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>ls-field-lg</td>
+        <td>
+          <label class="ls-label col-md-12 col-xs-12">
+            <div class="ls-prefix-group ls-field-lg">
+              <span class="ls-label-text-prefix">URL</span>
+              <input type="text" name="nome" required >
+            </div>
+          </label>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="ls-box-demo">
+
+  <%= partial 'documentacao/shared/form/fields-prefix-sizes.erb' %>
+  </div>
+<% code("html") do %>
+  <%= partial 'documentacao/shared/form/fields-prefix-sizes.erb' %>
+<% end %>
+
+
 </section>

--- a/source/documentacao/shared/form/_fields-prefix-sizes.erb
+++ b/source/documentacao/shared/form/_fields-prefix-sizes.erb
@@ -1,9 +1,5 @@
 <form action="" class="ls-form ls-form-horizontal row">
-  <label class="ls-label col-md-6">
-    <b class="ls-label-text">Nome</b>
-    <input type="text" class="ls-field-lg" name="nome" placeholder="Nome e sobrenome" required >
-  </label>
-  <label class="ls-label col-md-6 col-xs-12">
+  <label class="ls-label col-md-12 col-xs-12">
     <b class="ls-label-text">E-mail</b>
     <div class="ls-prefix-group ls-field-lg">
       <span class="ls-label-text-prefix">URL</span>

--- a/source/documentacao/shared/form/_fields-prefix-sizes.erb
+++ b/source/documentacao/shared/form/_fields-prefix-sizes.erb
@@ -1,0 +1,58 @@
+<form action="" class="ls-form ls-form-horizontal row">
+  <label class="ls-label col-md-6">
+    <b class="ls-label-text">Nome</b>
+    <input type="text" class="ls-field-lg" name="nome" placeholder="Nome e sobrenome" required >
+  </label>
+  <label class="ls-label col-md-6 col-xs-12">
+    <b class="ls-label-text">E-mail</b>
+    <div class="ls-prefix-group ls-field-lg">
+      <span class="ls-label-text-prefix">URL</span>
+      <input type="text" name="nome" required >
+    </div>
+  </label>
+  <div class="ls-actions-btn">
+    <button class="ls-btn ls-btn-lg">Salvar</button>
+    <button class="ls-btn-danger ls-btn-lg">Cancelar</button>
+  </div>
+</form>
+
+<form action="" class="ls-form ls-form-inline row">
+  <label class="ls-label col-md-11 col-xs-12">
+    <b class="ls-label-text">Digite seu site</b>
+    <div class="ls-prefix-group ls-field-md">
+      <span class="ls-label-text-prefix">URL</span>
+      <input type="text" name="nome" required >
+    </div>
+  </label>
+  <div class="ls-actions-btn">
+    <button class="ls-btn">Salvar</button>
+  </div>
+</form>
+
+<form action="" class="ls-form ls-form-inline row">
+  <label class="ls-label col-md-11 col-xs-12">
+    <b class="ls-label-text">Domínio</b>
+    <div class="ls-prefix-group ls-field-sm">
+      <span class="ls-label-text-prefix">www</span>
+      <input type="text" name="nome" required >
+      <span class="ls-label-text-prefix">.com.br</span>
+    </div>
+  </label>
+  <div class="ls-actions-btn">
+    <button class="ls-btn ls-btn-sm">Enviar</button>
+  </div>
+</form>
+
+
+<form action="" class="ls-form ls-form-inline row">
+  <label class="ls-label col-md-8 col-xs-12">
+    <b class="ls-label-text ls-hidden-accessible">E-mail</b>
+    <div class="ls-prefix-group ls-field-xs">
+      <span class="ls-label-text-prefix">URL</span>
+      <input type="text" name="nome" required >
+    </div>
+  </label>
+  <div class="ls-actions-btn">
+    <button class="ls-btn ls-btn-xs">Salvar</button>
+  </div>
+</form>


### PR DESCRIPTION
close #1672 

- [x] Criando variações de altura em elementos com prefixo e sufixo
- [x] Atualização da documentação

Criei as variações de tamanhos seguindo o padrão do projeto.
Agora podemos ter variações de altura também pra inputs com prefixos e sufixos, antes já tinhamos nos botões, select e inputs.

![prefix-ok](https://cloud.githubusercontent.com/assets/1235904/14363333/11a69f3a-fcda-11e5-87be-a8abe05dfe2a.jpg)
