### PR TITLE
Correção do bug do char counter

### DIFF
--- a/source/assets/javascripts/locastyle/_char-counter.js
+++ b/source/assets/javascripts/locastyle/_char-counter.js
@@ -9,13 +9,15 @@ locastyle.charCounter = (function() {
 
   function countText() {
     $('[data-ls-module="charCounter"]').each(function(index, field) {
+      $('.ls-number-counter-' + index).parent().remove();
+
       var limit = $(field).attr('maxlength');
       var html = '<p class="ls-help-inline"><small><strong ' +
         'class="ls-char-count ls-number-counter-' + index + '">' + limit +
         '</strong> caracteres restantes</small></p>';
       var prefixGroup = $(field).closest('.ls-prefix-group');
 
-      $(field).removeAttr('maxlength').data().maxlength = limit;
+      $(field).data().maxlength = limit;
 
       if (prefixGroup.length) {
         prefixGroup.after(html);

--- a/source/assets/javascripts/locastyle/_char-counter.js
+++ b/source/assets/javascripts/locastyle/_char-counter.js
@@ -9,7 +9,7 @@ locastyle.charCounter = (function() {
 
   function countText() {
     $('[data-ls-module="charCounter"]').each(function(index, field) {
-      $('.ls-number-counter-' + index).parent().remove();
+      $('.ls-number-counter-' + index).parents('.ls-help-inline').remove();
 
       var limit = $(field).attr('maxlength');
       var html = '<p class="ls-help-inline"><small><strong ' +


### PR DESCRIPTION
#1693 Por algum motivo nessa linha, $(field)**.removeAttr('maxlength')**.data().maxlength = limit; o código em destaque foi inserido, isso fez com que ao inicializar o módulo novamente o retorno é **NAN** uma vez que não existe mais o atributo **maxlength**, removi e voltou a funcionar, e o que eu fiz no inicio do método `countText()` após o `each` é toda vez que ele iniciar remove o que existe e cria novamente, não é um problema fazer isso.

Dessa maneira, os campos que já estão preenchidos não serão afetados zerando o contador, vai manter o estado atual e vai dar init somente nos campos novos.