### PR TITLE
Refatoração do Módulo Collapse

### DIFF
--- a/source/assets/javascripts/locastyle/_collapse.js
+++ b/source/assets/javascripts/locastyle/_collapse.js
@@ -1,4 +1,5 @@
 var locastyle = locastyle || {};
+
 locastyle.collapse = (function() {
   'use strict';
 
@@ -13,28 +14,39 @@ locastyle.collapse = (function() {
       close: 'ls-collapse-close',
       opened: 'ls-collapse-opened',
       alwaysOpened: 'ls-collapse-opened-always'
+    },
+    event: {
+      click: 'click.ls'
     }
   };
 
   function init() {
-    // set attributes from all collapses on load
     $(config.trigger).each(function() {
       ariaCollapse($(this));
     });
     bind();
   }
 
+  // bind the collapse event
   function bind() {
     $(config.trigger).each(function(index, element) {
-      if (!$(element).hasClass(config.classes.alwaysOpened)) {
-        $(element).find(config.classes.header).on('click.ls', function() {
-          groupCollapse($(element));
-          // get target
-          var target = $(element).data('target');
-          // set event
-          eventsHandler($(element));
-          // set aria's attributes
-          ariaCollapse($(element));
+      var collapse = $(element);
+
+      if (!collapse.hasClass(config.classes.alwaysOpened)) {
+        collapse.find(config.classes.header).on(config.event.click, function(e) {
+          e.preventDefault();
+          groupCollapse(collapse);
+          eventsHandler(collapse);
+          ariaCollapse(collapse);
+        });
+      }
+
+      // trigger collapse event from another element
+      if (collapse.find(config.classes.header).length === 0) {
+        collapse.off(config.event.click);
+        collapse.on(config.event.click, function(e) {
+          e.preventDefault();
+          toggle($(element).data('target'));
         });
       }
     });
@@ -44,10 +56,11 @@ locastyle.collapse = (function() {
   function groupCollapse(collapse) {
     var $group = collapse.parents(config.classes.groupContainer);
     if ($group[0]) {
-      $group.find(config.trigger).not(collapse).removeClass(config.classes.opened).find(config.classes.content).slideUp();
+      $group.find(config.trigger).not(collapse).removeClass(config.classes.opened);
     }
   }
 
+  // triggers events and change the collapse behavior
   function eventsHandler(el) {
     if (el.hasClass(config.classes.opened)) {
       el.removeClass(config.classes.opened);
@@ -58,7 +71,7 @@ locastyle.collapse = (function() {
     }
   }
 
-
+  // set aria's attributes
   function ariaCollapse(elem) {
     if ($(elem).hasClass(config.classes.opened)) {
       $(elem).find(config.classes.header).attr({ 'aria-expanded': true });
@@ -69,7 +82,13 @@ locastyle.collapse = (function() {
     }
   }
 
+  // toggle collapse behavior
+  function toggle(elem) {
+    $(elem).prev(config.classes.header).trigger(config.event.click);
+  }
+
   return {
-    init: init
+    init: init,
+    toggle: toggle
   };
 }());

--- a/source/assets/javascripts/locastyle/_collapse.js
+++ b/source/assets/javascripts/locastyle/_collapse.js
@@ -6,19 +6,19 @@ locastyle.collapse = (function() {
   var config = {
     trigger: '[data-ls-module="collapse"]',
     classes: {
-      header        : '.ls-collapse-header',
-      content       : '.ls-collapse-body',
+      header: '.ls-collapse-header',
+      content: '.ls-collapse-body',
       groupContainer: '.ls-collapse-group',
-      open          : 'ls-collapse-open',
-      close         : 'ls-collapse-close',
-      opened        : 'ls-collapse-opened',
-      alwaysOpened  : 'ls-collapse-opened-always'
+      open: 'ls-collapse-open',
+      close: 'ls-collapse-close',
+      opened: 'ls-collapse-opened',
+      alwaysOpened: 'ls-collapse-opened-always'
     }
   };
 
   function init() {
     // set attributes from all collapses on load
-    $(config.classes.header).each(function() {
+    $(config.trigger).each(function() {
       ariaCollapse($(this));
     });
     bind();
@@ -27,19 +27,14 @@ locastyle.collapse = (function() {
   function bind() {
     $(config.trigger).each(function(index, element) {
       if (!$(element).hasClass(config.classes.alwaysOpened)) {
-        $(element).on('click.ls', function() {
-          groupCollapse($(this));
+        $(element).find(config.classes.header).on('click.ls', function() {
+          groupCollapse($(element));
           // get target
-          var target = $(this).data('target');
-          // set aria's attributes
-          ariaCollapse($(this));
+          var target = $(element).data('target');
           // set event
-          eventsHandler($(this), target);
-
-        });
-        // if click on ck-collapse-body no action happens
-        $(config.classes.content).on('click.ls', function(event) {
-          event.stopPropagation();
+          eventsHandler($(element));
+          // set aria's attributes
+          ariaCollapse($(element));
         });
       }
     });
@@ -53,29 +48,28 @@ locastyle.collapse = (function() {
     }
   }
 
-  function eventsHandler(el, target) {
-    if($(target).parent().hasClass(config.classes.opened)) {
-      $(target).parent().removeClass(config.classes.opened);
+  function eventsHandler(el) {
+    if (el.hasClass(config.classes.opened)) {
+      el.removeClass(config.classes.opened);
       el.trigger('collapse:closed');
     } else {
-      $(target).parent().addClass(config.classes.opened);
+      el.addClass(config.classes.opened);
       el.trigger('collapse:opened');
     }
   }
 
 
   function ariaCollapse(elem) {
-    if($(elem).hasClass(config.classes.open)){
-      $(config.classes.header).attr({ 'aria-expanded' : true });
-      $(config.classes.content).attr({ 'aria-hidden' : false });
-    }else{
-      $(config.classes.header).attr({ 'aria-expanded' : false });
-      $(config.classes.content).attr({ 'aria-hidden' : true });
+    if ($(elem).hasClass(config.classes.opened)) {
+      $(elem).find(config.classes.header).attr({ 'aria-expanded': true });
+      $(elem).find(config.classes.content).attr({ 'aria-hidden': false });
+    } else {
+      $(elem).find(config.classes.header).attr({ 'aria-expanded': false });
+      $(elem).find(config.classes.content).attr({ 'aria-hidden': true });
     }
   }
 
   return {
     init: init
   };
-
 }());

--- a/source/assets/stylesheets/locastyle/base/_placeholders.sass
+++ b/source/assets/stylesheets/locastyle/base/_placeholders.sass
@@ -3,3 +3,15 @@
   margin: 30px 0
   border-top: 4px solid $gray1
   white-space: nowrap
+
+%hide-element
+  height: 0
+  opacity: 0
+  overflow: hidden
+  visibility: hidden
+
+%show-element
+  height: auto
+  opacity: 1
+  overflow: initial
+  visibility: visible

--- a/source/assets/stylesheets/locastyle/modules/_collapse.sass
+++ b/source/assets/stylesheets/locastyle/modules/_collapse.sass
@@ -16,9 +16,6 @@
   font-size: remtopx(.875)
   margin-bottom: 10px
 
-  .ls-collapse-body
-    padding: 10px
-
 .ls-collapse-opened,
 .ls-collapse-opened-always
 
@@ -26,7 +23,8 @@
     +rotate(180deg)
 
   .ls-collapse-body
-    display: block
+    padding: 10px
+    @extend %show-element
 
 .ls-collapse-header
   display: block
@@ -62,4 +60,5 @@
 
 .ls-collapse-body
   border: 0px solid transparent
-  display: none
+  padding: 0
+  @extend %hide-element

--- a/source/documentacao/componentes/collapse.html.erb
+++ b/source/documentacao/componentes/collapse.html.erb
@@ -86,11 +86,12 @@ type: component
   </table>
 
   <h2 class="doc-title-3">Abrir/Fechar o Collapse</h2>
+  <p>Utilize a função <code>.toggle()</code> para controlar o comportamento do collapse.</p>
   <% code("javascript") do %>locastyle.collapse.toggle('#element')<% end %>
 
-
-
   <hr>
+
+  <p>Você também pode utilizar outros elementos para abrir/fechar um collapse. Para isso, inicialize o módulo normalmente utilizando o <code>data-ls-module="collapse"</code> no elemento que deseja utilizar como trigger e também o atributo <code>data-target="#target"</code> para indicar o collapse alvo.</p>
   <div class="ls-box-demo">
     <button type="button" class="ls-btn-primary" data-ls-module="collapse" data-target="#010">Abre/Fecha o <i>collapse</i></button>
     <br>
@@ -104,10 +105,10 @@ type: component
 
   <div class="ls-box-demo">
     <div class="ls-collapse-group">
-      <%= partial('documentacao/shared/collapse/collapse', :locals => { :id => "acordeon", :quant => 2, :header => "Título", content: (lorem.paragraphs 1)  }) %>
+      <%= partial('documentacao/shared/collapse/collapse', :locals => { :id => "accordeon", :quant => 2, :header => "Título", content: (lorem.paragraphs 1)  }) %>
     </div>
   </div>
-  <% code("html") do %><%= partial('documentacao/shared/collapse/collapse', :locals => { :id => "acordeon", :quant => 2, :header => "Título", content: (lorem.paragraphs 1)  }) %><% end %>
+  <% code("html") do %><%= partial('documentacao/shared/collapse/collapse-group', :locals => { :id => "accordeon", :quant => 2, :header => "Título", content: (lorem.paragraphs 1)  }) %><% end %>
 
 
   <h2 class="doc-title-3">Eventos</h2>
@@ -144,4 +145,3 @@ $(".ls-collapse").on('collapse:closed', function(){
   <%end%>
 
 </section>
-

--- a/source/documentacao/shared/collapse/_collapse-group.erb
+++ b/source/documentacao/shared/collapse/_collapse-group.erb
@@ -1,0 +1,23 @@
+<div class="ls-collapse-group">
+  <% quant.times do |num| %>
+  <div data-ls-module="collapse" data-target="#<%= id %><%= num %>" class="ls-collapse<% if defined?(startOpen) %> ls-collapse-open <% end %> <% if defined?(alwaysOpen) %> ls-collapse-opened-always <% end %>">
+    <a href="#" class="ls-collapse-header">
+      <% if header.is_a? String %>
+      <h3 class="ls-collapse-title"><%= header %> <%= num+1 %></h3>
+      <% else %>
+      <h3 class="ls-collapse-title">
+        <%= header[:title] %>
+      </h3>
+      <p>
+        <%= header[:desc] %>
+      </p>
+      <% end %>
+    </a>
+    <div class="ls-collapse-body" id="<%= id %><%= num %>">
+      <p>
+        <%= content %>
+      </p>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/spec/javascripts/collapse_spec.js
+++ b/spec/javascripts/collapse_spec.js
@@ -8,17 +8,17 @@ describe('Collapse:', function() {
 
   describe('When click to open collapse', function() {
     it('should target be visible', function() {
-      $('#myCollapse1 [data-ls-module="collapse"]').trigger('click');
+      $('#myCollapse1 .ls-collapse-header').trigger('click');
       expect($('#collapse1')).toBeVisible();
     });
 
     it("should trigger the event collapse:opened", function() {
       var spyEvent = spyOnEvent(document, 'collapse:opened');
-      $('#myCollapse1 [data-ls-module="collapse"]').trigger("click");
+      $('#myCollapse1 .ls-collapse-header').trigger("click");
       expect('collapse:opened').toHaveBeenTriggeredOn(document);
 
       var spyEvent = spyOnEvent(document, 'collapse:closed');
-      $('#myCollapse1 [data-ls-module="collapse"]').trigger("click");
+      $('#myCollapse1 .ls-collapse-header').trigger("click");
       expect('collapse:closed').toHaveBeenTriggeredOn(document);
     });
 

--- a/spec/javascripts/collapse_spec.js
+++ b/spec/javascripts/collapse_spec.js
@@ -1,9 +1,7 @@
 describe('Collapse:', function() {
-
   beforeEach(function() {
     loadFixtures('collapse_fixture.html');
     locastyle.collapse.init();
-
   });
 
   describe('When click to open collapse', function() {
@@ -12,16 +10,57 @@ describe('Collapse:', function() {
       expect($('#collapse1')).toBeVisible();
     });
 
-    it("should trigger the event collapse:opened", function() {
+    it('should trigger the event collapse:opened', function() {
       var spyEvent = spyOnEvent(document, 'collapse:opened');
-      $('#myCollapse1 .ls-collapse-header').trigger("click");
+      $('#myCollapse1 .ls-collapse-header').trigger('click');
       expect('collapse:opened').toHaveBeenTriggeredOn(document);
 
       var spyEvent = spyOnEvent(document, 'collapse:closed');
-      $('#myCollapse1 .ls-collapse-header').trigger("click");
+      $('#myCollapse1 .ls-collapse-header').trigger('click');
       expect('collapse:closed').toHaveBeenTriggeredOn(document);
     });
+  });
 
+  describe('when the collapse is opened', function() {
+    var collapse = null;
+    var collapseHeader = null;
+    var collapseBody = null;
+
+    beforeEach(function() {
+      collapse = $('#myCollapse1');
+      collapseHeader = collapse.find('.ls-collapse-header');
+      collapseBody = collapse.find('.ls-collapse-body');
+      collapseHeader.trigger('click');
+    });
+
+    it('should add the aria-expanded true to collapse header', function() {
+      expect(collapseHeader.attr('aria-expanded')).toBe('true');
+    });
+
+    it('should add the aria-hidden false to collapse header', function() {
+      expect(collapseBody.attr('aria-hidden')).toBe('false');
+    });
+
+    describe('when the collapse is close', function() {
+      beforeEach(function() {
+        collapseHeader.trigger('click');
+      });
+
+      it('should add the aria-expanded false to collapse header', function() {
+        expect(collapseHeader.attr('aria-expanded')).toBe('false');
+      });
+
+      it('should add the aria-hidden true to collapse header', function() {
+        expect(collapseBody.attr('aria-hidden')).toBe('true');
+      });
+    });
+  });
+
+  describe('when use another element to trigger the collapse', function() {
+    it('should toggle the collapse state', function() {
+      $('#button-trigger').trigger('click');
+      expect($('#myCollapse4')).toBeVisible();
+    });
   });
 
   describe('When collapse have a class ls-collapse-opened', function() {
@@ -37,22 +76,19 @@ describe('Collapse:', function() {
     });
   });
 
-
   describe('Group / Accordeon', function() {
-
     it('open collapse, close others', function() {
       var $collapseClose = $('#collapse4');
       var $collapseCloseBody = $collapseClose.find('.ls-collapse-body');
       var $collapseOpen = $('#collapse5');
       var $collapseOpenTitle = $collapseOpen.find('.ls-collapse-body');
-      $collapseOpen.trigger("click");
+
+      $collapseOpen.trigger('click');
       expect($collapseOpen.is(':visible')).toBe(true);
       expect($collapseClose.is(':visible')).toBe(true);
-      $collapseClose.trigger("click");
+      $collapseClose.trigger('click');
       expect($collapseOpen.is(':visible')).toBe(true);
       expect($collapseClose.is(':visible')).toBe(true);
     });
-
   });
-
 });

--- a/spec/javascripts/fixtures/collapse_fixture.html
+++ b/spec/javascripts/fixtures/collapse_fixture.html
@@ -37,7 +37,6 @@
   </div>
 </div>
 
-
 <div id="myCollapse4">
   <div data-ls-module="collapse" data-target="#collapse4" class="ls-collapse">
     <a href="#" class="ls-collapse-header">
@@ -50,6 +49,8 @@
     </div>
   </div>
 </div>
+
+<button type="button" id="button-trigger" data-ls-module="collapse" data-target="#collapse4">Abre/Fecha o <i>collapse</i></button>
 
 <div class="ls-collapse-group" id="accordeon1">
   <div id="collapse4" class="ls-collapse" data-ls-module="collapse">


### PR DESCRIPTION
Atualizando um projeto para o Locastyle V3, percebi que a forma como o collapse foi desenvolvido, estava prejudicando o funcionamento de alguns eventos do Rails e do CKEditor.

1 - Os eventos ajax do Rails (remote) estavam sendo anulados pelo o `e.stopPropagation()` atribuído ao click no `ls-collapse-body`. Devido esse problema, modifiquei o trigger de acionamento do módulo para ser somente o `ls-collapse-header`, que já era o comportamento esperado pelo uso do stopPropagation.

2 - A utilização do `display: none` para mostrar ou não o collapse, estava interferindo nos eventos do CKEditor que não estavam sendo inicializados de forma correta. A solução para esse problema foi utilizar uma abordagem, escondendo ou não o elemento, através das propriedades `opacity, visibility, overflow, e height`.

3 - A documentação foi atualizada para explicar melhor a utilização de outros elementos para manipular um collapse.

4 - A função `toggle` estava na documentação, mas não estava implementada no módulo.

5 - Foram adicionados alguns testes que estavam faltando no módulo.