### PR TITLE
Alteração no flex do ls-box-body

### DIFF
--- a/source/assets/stylesheets/locastyle/modules/_board-info.sass
+++ b/source/assets/stylesheets/locastyle/modules/_board-info.sass
@@ -62,7 +62,7 @@
     .ls-box-body
       width: 100%
       min-height: 76px
-      flex: 1
+      flex: 2
       padding-bottom: 10px
 
       small


### PR DESCRIPTION
Modifiquei o valor no flex do `ls-box-body` para permitir que o `ls-board-box` possa ser utilizado com uma estrutura utilizando somente o header e o body.

Antes:
![image](https://cloud.githubusercontent.com/assets/5097397/18714862/7f74b466-7fed-11e6-84f0-d9f4c7f5b85c.png)

Depois:
![image](https://cloud.githubusercontent.com/assets/5097397/18714880/8a5592e2-7fed-11e6-933d-cab32ee940cf.png)
