### PR TITLE
Path do css da documentação

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -92,6 +92,9 @@ set :css_dir, 'assets/stylesheets'
 set :js_dir, 'assets/javascripts'
 set :images_dir, 'assets/images'
 
+set :path_css, '/assets/stylesheets/locastyle.css'
+version = , "3.10.0"
+
 activate :directory_indexes
 activate :i18n
 
@@ -120,4 +123,8 @@ configure :build do
 
   # base url for gh-pages
   set :base_url, "/locawebstyle"
+
+  # path css production
+  set :path_css, '//assets.locaweb.com.br/locastyle/'+ version + '/stylesheets/locastyle.css'
+
 end

--- a/config.rb
+++ b/config.rb
@@ -86,14 +86,14 @@ helpers CustomHelpers
 
 set :base_url, ""
 
-set :stable, "3.9.0"
+set :stable, "3.10.0"
 
 set :css_dir, 'assets/stylesheets'
 set :js_dir, 'assets/javascripts'
 set :images_dir, 'assets/images'
 
 set :path_css, '/assets/stylesheets/locastyle.css'
-version = "3.9.0"
+version = "3.10.0"
 
 activate :directory_indexes
 activate :i18n

--- a/config.rb
+++ b/config.rb
@@ -86,14 +86,14 @@ helpers CustomHelpers
 
 set :base_url, ""
 
-set :stable, "3.10.0"
+set :stable, "3.9.0"
 
 set :css_dir, 'assets/stylesheets'
 set :js_dir, 'assets/javascripts'
 set :images_dir, 'assets/images'
 
 set :path_css, '/assets/stylesheets/locastyle.css'
-version = , "3.10.0"
+version = "3.9.0"
 
 activate :directory_indexes
 activate :i18n

--- a/config.rb
+++ b/config.rb
@@ -93,7 +93,6 @@ set :js_dir, 'assets/javascripts'
 set :images_dir, 'assets/images'
 
 set :path_css, '/assets/stylesheets/locastyle.css'
-version = "3.10.0"
 
 activate :directory_indexes
 activate :i18n
@@ -125,6 +124,6 @@ configure :build do
   set :base_url, "/locawebstyle"
 
   # path css production
-  set :path_css, '//assets.locaweb.com.br/locastyle/'+ version + '/stylesheets/locastyle.css'
+  set :path_css, '//assets.locaweb.com.br/locastyle/'+ config[:stable]  + '/stylesheets/locastyle.css'
 
 end

--- a/scripts/tasks/deploy.rake
+++ b/scripts/tasks/deploy.rake
@@ -10,15 +10,15 @@ namespace :deploy do
     copy_to_assets_and_dist(args[:version])
     update_bower_version(args[:version])
     update_package_version(args[:version])
-    update_stable_in_config(args[:version])
+    update_version_in_config(args[:version])
     commit_and_tag_assets(args[:version])
     git_commit_and_tag_locastyle(args[:version])
   end
 
-  def update_stable_in_config(version)
+  def update_version_in_config(version)
     bower_json = File.open("config.rb", "r").read
-    update_stable = bower_json.gsub(/(set :stable, "\d.\d{1,2}.\d{1,3}")/, "set :stable, \"#{version}\"")
-    File.open("config.rb", "w") {|file| file.puts update_stable}
+    update_version = bower_json.gsub(/(set :stable, "\d.\d{1,2}.\d{1,3}")/, "set :stable, \"#{version}\"")
+    File.open("config.rb", "w") {|file| file.puts update_version}
   end
 
   def update_package_version(version)

--- a/scripts/tasks/deploy.rake
+++ b/scripts/tasks/deploy.rake
@@ -11,7 +11,6 @@ namespace :deploy do
     update_bower_version(args[:version])
     update_package_version(args[:version])
     update_stable_in_config(args[:version])
-    update_version_in_config(args[:version])
     commit_and_tag_assets(args[:version])
     git_commit_and_tag_locastyle(args[:version])
   end
@@ -20,12 +19,6 @@ namespace :deploy do
     bower_json = File.open("config.rb", "r").read
     update_stable = bower_json.gsub(/(set :stable, "\d.\d{1,2}.\d{1,3}")/, "set :stable, \"#{version}\"")
     File.open("config.rb", "w") {|file| file.puts update_stable}
-  end
-
-  def update_version_in_config(version)
-    bower_json = File.open("config.rb", "r").read
-    update_version = bower_json.gsub(/(version = "\d.\d{1,2}.\d{1,3}")/, "version = \"#{version}\"")
-    File.open("config.rb", "w") {|file| file.puts update_version}
   end
 
   def update_package_version(version)

--- a/scripts/tasks/deploy.rake
+++ b/scripts/tasks/deploy.rake
@@ -10,14 +10,21 @@ namespace :deploy do
     copy_to_assets_and_dist(args[:version])
     update_bower_version(args[:version])
     update_package_version(args[:version])
+    update_stable_in_config(args[:version])
     update_version_in_config(args[:version])
     commit_and_tag_assets(args[:version])
     git_commit_and_tag_locastyle(args[:version])
   end
 
+  def update_stable_in_config(version)
+    bower_json = File.open("config.rb", "r").read
+    update_stable = bower_json.gsub(/(set :stable, "\d.\d{1,2}.\d{1,3}")/, "set :stable, \"#{version}\"")
+    File.open("config.rb", "w") {|file| file.puts update_stable}
+  end
+
   def update_version_in_config(version)
     bower_json = File.open("config.rb", "r").read
-    update_version = bower_json.gsub(/(set :stable, "\d.\d{1,2}.\d{1,3}")/, "set :stable, \"#{version}\"")
+    update_version = bower_json.gsub(/(version = "\d.\d{1,2}.\d{1,3}")/, "version = \"#{version}\"")
     File.open("config.rb", "w") {|file| file.puts update_version}
   end
 

--- a/source/partials/_doc-header.html.erb
+++ b/source/partials/_doc-header.html.erb
@@ -10,7 +10,7 @@
   <%= javascript_include_tag "libs/mediaqueries-ie", "libs/html5shiv" %>
 
   <%= stylesheet_link_tag "docs" %>
-  <link rel="stylesheet" href="<%= base_url %>/assets/stylesheets/locastyle.css">
+  <link rel="stylesheet" href="<%= path_css %>">
 
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Esse PR faz uma melhoria na documentacão, desenvolvendo o css continua sendo do localhost, mas ao fazer o build a documentação utiliza o caminho do locawebstyle em produção.

-------

Para testar entre na branch e faça  o comando  `middleman build` , dentro da pasta `build` verifique se o caminho do css do arquivo `index.html` está semelhante ao código abaixo

```
//assets.locaweb.com.br/locastyle/{ultima_versao}/stylesheets/locastyle.css