### PR TITLE
Atualização da documentação do popover

### DIFF
--- a/source/documentacao/componentes/popover.html.erb
+++ b/source/documentacao/componentes/popover.html.erb
@@ -58,7 +58,7 @@ type: component
         <td>insere o conteúdo no popover</td>
       </tr>
       <tr>
-        <td>data-custom-classes</td>
+        <td>data-custom-class</td>
         <td>classe</td>
         <td>--</td>
         <td>permite inserir qualquer classe para customização do popover. Os valores colocados aqui, serão herdados pelo elemento do popover</td>

--- a/source/documentacao/exemplos/painel2/config-email.html.erb
+++ b/source/documentacao/exemplos/painel2/config-email.html.erb
@@ -47,7 +47,7 @@ title_product: SMTP Locaweb
       </tr>
       <tr>
         <td>seudominio2.com.br</td>
-        <td><span class="ls-word-dotted" data-ls-module="popover" data-title="Não Configurado" data-content="A configuração tem um tempo de até 24 horas para propagar após a inserção da entrada em seu gerenciador de DNS." data-placement="right" data-trigger="hover" data-custom-classes="ls-width-250">Não Configurado</span></td>
+        <td><span class="ls-word-dotted" data-ls-module="popover" data-title="Não Configurado" data-content="A configuração tem um tempo de até 24 horas para propagar após a inserção da entrada em seu gerenciador de DNS." data-placement="right" data-trigger="hover" data-custom-class="ls-width-250">Não Configurado</span></td>
         <td class="ls-txt-right ls-regroup">
           <a href="#" class="ls-btn ls-btn-xs">Configurações do DNS</a>
           <div data-ls-module="dropdown" class="ls-dropdown ls-pos-right">

--- a/source/documentacao/exemplos/painel2/home.html.erb
+++ b/source/documentacao/exemplos/painel2/home.html.erb
@@ -91,7 +91,7 @@ title_product: SMTP Locaweb
     <div class="col-sm-3">
       <div class="ls-box">
         <div class="ls-box-head">
-          <h6 class="ls-title-4">Denúncias <a href="#" class="ls-ico-help" data-trigger="hover" data-ls-module="popover" data-placement="left" data-custom-classes="ls-width-300" data-content="<p>Este número corresponde ao número de vezes que seus destinatários marcaram suas mensagens como spam. Essas denúncias podem comprometer a entregabilidade das suas próximas mensagens.</p>"></a></h6>
+          <h6 class="ls-title-4">Denúncias <a href="#" class="ls-ico-help" data-trigger="hover" data-ls-module="popover" data-placement="left" data-custom-class="ls-width-300" data-content="<p>Este número corresponde ao número de vezes que seus destinatários marcaram suas mensagens como spam. Essas denúncias podem comprometer a entregabilidade das suas próximas mensagens.</p>"></a></h6>
         </div>
         <div class="ls-box-body">
           <span class="ls-board-data">
@@ -172,7 +172,7 @@ title_product: SMTP Locaweb
     </div>
   </div>
   <br>
-  <p class="ls-txt-right">Status anti-fraude: <strong class="ls-color-success">Aprovado</strong> <span style="clear: both;" class="ls-ico-help anti-fraud-pop" data-trigger="hover" data-ls-module="popover" data-placement="left" data-custom-classes="ls-width-300" data-title="Sua conta está &quot;Aprovada&quot;!" data-content="Status antifraude é uma verificação do comportamento de envio da conta."></span></p>
+  <p class="ls-txt-right">Status anti-fraude: <strong class="ls-color-success">Aprovado</strong> <span style="clear: both;" class="ls-ico-help anti-fraud-pop" data-trigger="hover" data-ls-module="popover" data-placement="left" data-custom-class="ls-width-300" data-title="Sua conta está &quot;Aprovada&quot;!" data-content="Status antifraude é uma verificação do comportamento de envio da conta."></span></p>
 </div>
 
 <%= partial 'documentacao/exemplos/painel2/change-password' %>

--- a/source/documentacao/exemplos/painel5/pre-painel.html.erb
+++ b/source/documentacao/exemplos/painel5/pre-painel.html.erb
@@ -68,7 +68,7 @@ topbar_gray: true
   <div class="ls-list-content ">
     <div class="col-md-12">
       <span class="ls-list-label">Domínio</span>
-      <strong>Não registrado</strong> <a href="#" class="ls-ico-help" data-trigger="hover" data-ls-module="popover" data-placement="right" data-custom-classes="ls-width-300" data-content="<p>Este domínio parece não estar registrado.</p>"></a>
+      <strong>Não registrado</strong> <a href="#" class="ls-ico-help" data-trigger="hover" data-ls-module="popover" data-placement="right" data-custom-class="ls-width-300" data-content="<p>Este domínio parece não estar registrado.</p>"></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Atualizei a documentação do popover para corrigir os exemplos de uso da opção `data-custom-class` que estava como `data-custom-classes`. Para um primeiro momento, fiz uma simples correção na documentação, assim não teremos problemas com implementações existentes.

closes #1755 