### PR TITLE
Change the base font from open sans to ubuntu

### DIFF
--- a/source/assets/stylesheets/docs/_base.sass
+++ b/source/assets/stylesheets/docs/_base.sass
@@ -1,5 +1,5 @@
 @import "compass/css3"
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,300,700)
+@import url('https://fonts.googleapis.com/css?family=Ubuntu:300,300i,400,400i,700,700i')
 
 *
   margin: 0
@@ -17,7 +17,7 @@ html
 
 body
   overflow: auto !important
-  font-family: 'Open Sans', sans-serif
+  font-family: 'Ubuntu', sans-serif
 
 h1,h2,h3,h4,h5,h6
   -webkit-font-smoothing: antialiased

--- a/source/assets/stylesheets/docs/_base.sass
+++ b/source/assets/stylesheets/docs/_base.sass
@@ -1,5 +1,5 @@
 @import "compass/css3"
-@import url('https://fonts.googleapis.com/css?family=Ubuntu:300,300i,400,400i,700,700i')
+@import url('//fonts.googleapis.com/css?family=Ubuntu:300,300i,400,400i,700,700i')
 
 *
   margin: 0
@@ -17,7 +17,7 @@ html
 
 body
   overflow: auto !important
-  font-family: 'Ubuntu', sans-serif
+  font-family: 'Ubuntu', Arial, Helvetica, Sans-serif
 
 h1,h2,h3,h4,h5,h6
   -webkit-font-smoothing: antialiased

--- a/source/assets/stylesheets/locastyle/base/_fonts.sass
+++ b/source/assets/stylesheets/locastyle/base/_fonts.sass
@@ -1,7 +1,7 @@
 ///
 /// Importing fonts
 ///
-@import url(//fonts.googleapis.com/css?family=Open+Sans:300,400,600,700)
+@import url('https://fonts.googleapis.com/css?family=Ubuntu:300,300i,400,400i,700,700i')
 
 @font-face
   font-family: 'locastyle'

--- a/source/assets/stylesheets/locastyle/base/_fonts.sass
+++ b/source/assets/stylesheets/locastyle/base/_fonts.sass
@@ -1,7 +1,7 @@
 ///
 /// Importing fonts
 ///
-@import url('https://fonts.googleapis.com/css?family=Ubuntu:300,300i,400,400i,700,700i')
+@import url('//fonts.googleapis.com/css?family=Ubuntu:300,300i,400,400i,700,700i')
 
 @font-face
   font-family: 'locastyle'

--- a/source/assets/stylesheets/locastyle/base/_reset.sass
+++ b/source/assets/stylesheets/locastyle/base/_reset.sass
@@ -20,7 +20,7 @@ body
 body
   font-size: 100%
   line-height: 1
-  font-family: Ubuntu, Arial, Helvetica, Sans-serif
+  font-family: $default-font
 
 .container-white
   @extend .ls-clearfix

--- a/source/assets/stylesheets/locastyle/base/_reset.sass
+++ b/source/assets/stylesheets/locastyle/base/_reset.sass
@@ -20,7 +20,7 @@ body
 body
   font-size: 100%
   line-height: 1
-  font-family: Open Sans, Arial, Helvetica, Sans-serif
+  font-family: Ubuntu, Arial, Helvetica, Sans-serif
 
 .container-white
   @extend .ls-clearfix

--- a/source/assets/stylesheets/locastyle/base/_variables.scss
+++ b/source/assets/stylesheets/locastyle/base/_variables.scss
@@ -35,3 +35,7 @@ $spacers: (
   md: 20px,
   lg: 40px,
 );
+
+// FONTS
+$default-font: Ubuntu, Helvetica, Arial, Sans-serif;
+$sans-serif: Helvetica, Arial, Sans-serif;

--- a/source/assets/stylesheets/locastyle/modules/_datepicker.sass
+++ b/source/assets/stylesheets/locastyle/modules/_datepicker.sass
@@ -6,7 +6,7 @@
   background: #fff
   border: 1px solid #ccc
   border-bottom-color: #bbb
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
+  font-family: $sans-serif
 
   &:before
     content: " "

--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -61,7 +61,7 @@ input[type="week"],
 textarea
   +box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075))
   +transition(border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s)
-  font-family: Ubuntu, Arial, Helvetica, Sans-serif
+  font-family: $default-font
   font-size: remtopx(.8125)
   padding: 6px 11px 7px
   vertical-align: middle

--- a/source/assets/stylesheets/locastyle/modules/_forms.sass
+++ b/source/assets/stylesheets/locastyle/modules/_forms.sass
@@ -61,7 +61,7 @@ input[type="week"],
 textarea
   +box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075))
   +transition(border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s)
-  font-family: Open Sans, Arial, Helvetica, Sans-serif
+  font-family: Ubuntu, Arial, Helvetica, Sans-serif
   font-size: remtopx(.8125)
   padding: 6px 11px 7px
   vertical-align: middle

--- a/source/assets/stylesheets/locastyle/modules/_steps.sass
+++ b/source/assets/stylesheets/locastyle/modules/_steps.sass
@@ -71,7 +71,7 @@
   border: none
   cursor: none
   display: inline-block
-  font-family: Ubuntu, Arial, Helvetica, Sans-serif
+  font-family: $default-font
   font-size: remtopx(1.125)
   font-weight: 300
   color: $gray3
@@ -92,7 +92,7 @@
     height: 29px
     box-sizing: border-box
     content: counters(steps, "") " "
-    font-family: Ubuntu, Arial, Helvetica, Sans-serif
+    font-family: $default-font
     font-size: 15px
     font-weight: 300
     line-height: 25px

--- a/source/assets/stylesheets/locastyle/modules/_steps.sass
+++ b/source/assets/stylesheets/locastyle/modules/_steps.sass
@@ -71,7 +71,7 @@
   border: none
   cursor: none
   display: inline-block
-  font-family: Open Sans, Arial, Helvetica, Sans-serif
+  font-family: Ubuntu, Arial, Helvetica, Sans-serif
   font-size: remtopx(1.125)
   font-weight: 300
   color: $gray3
@@ -92,7 +92,7 @@
     height: 29px
     box-sizing: border-box
     content: counters(steps, "") " "
-    font-family: Open Sans, Arial, Helvetica, Sans-serif
+    font-family: Ubuntu, Arial, Helvetica, Sans-serif
     font-size: 15px
     font-weight: 300
     line-height: 25px

--- a/source/assets/stylesheets/locastyle/modules/_tabs-button.sass
+++ b/source/assets/stylesheets/locastyle/modules/_tabs-button.sass
@@ -8,7 +8,7 @@
       border-color: mix($color-mix, #fff, 20%)
       color: $gray4
       display: inline-block
-      font-family: Open Sans, Arial, Helvetica, Sans-serif
+      font-family: Ubuntu, Arial, Helvetica, Sans-serif
       font-size: remtopx(1)
       font-weight: 300
       padding: 12px 15px

--- a/source/assets/stylesheets/locastyle/modules/_tabs-button.sass
+++ b/source/assets/stylesheets/locastyle/modules/_tabs-button.sass
@@ -8,7 +8,7 @@
       border-color: mix($color-mix, #fff, 20%)
       color: $gray4
       display: inline-block
-      font-family: Ubuntu, Arial, Helvetica, Sans-serif
+      font-family: $default-font
       font-size: remtopx(1)
       font-weight: 300
       padding: 12px 15px

--- a/source/assets/stylesheets/locastyle/modules/_topbar.sass
+++ b/source/assets/stylesheets/locastyle/modules/_topbar.sass
@@ -87,7 +87,7 @@
         &:after
           content: attr(data-counter)
           position: absolute
-          font-family: arial, sans-serif
+          font-family: $sans-serif
           +border-circle(17px, 10px)
           background: #cc0000
           color: #fff


### PR DESCRIPTION
### Resumo

Substituição da fonte padrão do projeto de `Open Sans` para `Ubuntu`, de acordo com as definições de rebrand.

closes #1804 
