### PR TITLE
Rebrand da classes funcionais de cores

### DIFF
--- a/source/assets/stylesheets/locastyle/base/_color-theme.sass
+++ b/source/assets/stylesheets/locastyle/base/_color-theme.sass
@@ -23,11 +23,6 @@
     .ls-tag-primary
       background-color: $color1
 
-    .ls-background-primary,
-    .ls-table .ls-background-primary td
-      background-color: lighten($color1, 40%)
-      color: $color1
-
     ////
     // Topbar
     ////

--- a/source/assets/stylesheets/locastyle/base/_color-theme.sass
+++ b/source/assets/stylesheets/locastyle/base/_color-theme.sass
@@ -7,9 +7,6 @@
 
   .ls-theme-#{$theme-name}
 
-    .ls-color-theme
-      color: mix($color-mix, $color1, 20%)!important
-
     p a:not([class*="ls-btn"]),
     .ls-breadcrumb a,
     .hopscotch-bubble a

--- a/source/assets/stylesheets/locastyle/base/_fonts.sass
+++ b/source/assets/stylesheets/locastyle/base/_fonts.sass
@@ -50,7 +50,6 @@
   width: 5px
 
 .ls-ico-alone
-  @extend .ls-color-theme
   display: inline-block
   font-size: remtopx(4)
   border-bottom-color: transparent

--- a/source/assets/stylesheets/locastyle/base/_helper-classes.sass
+++ b/source/assets/stylesheets/locastyle/base/_helper-classes.sass
@@ -398,28 +398,47 @@
     content: " "
     display: table
 
+// The success, info, warning and danger background classes will be deprecated in the future.
 // BACKGROUND COLORS
-.ls-background-sucess,
-.ls-table .ls-background-sucess td,
 .ls-background-success,
-.ls-table .ls-background-success td
-  color: $color-success
-  background-color: lighten($color-success, 40%)
+.ls-table .ls-background-success td,
+.ls-background-success,
+.ls-table .ls-background-success td,
+.ls-background-green,
+.ls-table .ls-background-green td
+  color: $ls-color-green
+  background-color: lighten($color-success, 50%)
 
 .ls-background-info,
-.ls-table .ls-background-info td
-  color: $color-info
-  background-color: lighten($color-info, 40%)
+.ls-table .ls-background-info td,
+.ls-background-blue,
+.ls-table .ls-background-blue td
+  color: $ls-color-blue
+  background-color: lighten($color-info, 45%)
+
+.ls-background-oil-blue,
+.ls-table .ls-background-oil-blue td
+  color: $ls-color-oil-blue
+  background-color: lighten($ls-color-oil-blue, 50%)
 
 .ls-background-warning,
-.ls-table .ls-background-warning td
-  color: $color-warning
-  background-color: lighten($color-warning, 40%)
+.ls-table .ls-background-warning td,
+.ls-background-yellow,
+.ls-table .ls-background-yellow td
+  color: $ls-color-yellow
+  background-color: lighten($color-warning, 50%)
 
 .ls-background-danger,
-.ls-table .ls-background-danger td
-  color: $color-danger
-  background-color: lighten($color-danger, 40%)
+.ls-table .ls-background-danger td,
+.ls-background-red,
+.ls-table .ls-background-red td
+  color: $ls-color-red
+  background-color: lighten($color-danger, 35%)
+
+.ls-background-purple,
+.ls-table .ls-background-purple td
+  color: $ls-color-purple
+  background-color: lighten($ls-color-purple, 30%)
 
 //
 // Styling List

--- a/source/assets/stylesheets/locastyle/base/_helper-classes.sass
+++ b/source/assets/stylesheets/locastyle/base/_helper-classes.sass
@@ -233,27 +233,50 @@
   -ms-overflow-scrolling: touch
   overflow-scrolling: touch
 
+// OBS: The success, info, warning and danger color classes will be deprecated in the future.
 // COLORS
 .ls-bg-white
   background: #fff !important
 
-.ls-color-black
+.ls-color-black,
+.ls-table .ls-color-black td
   color: #000 !important
 
-.ls-color-white
-  color: #fff
+.ls-color-white,
+.ls-table .ls-color-white td
+  color: #fff !important
 
-.ls-color-danger
-  color: $color-danger !important
+.ls-color-danger,
+.ls-table .ls-color-danger td,
+.ls-color-red,
+.ls-table .ls-color-red td
+  color: $ls-color-red !important
 
-.ls-color-info
-  color: $color-info !important
+.ls-color-info,
+.ls-table .ls-color-info td,
+.ls-color-blue,
+.ls-table .ls-color-blue td
+  color: $ls-color-blue !important
 
-.ls-color-success
-  color: $color-success !important
+.ls-color-oil-blue,
+.ls-table .ls-color-oil-blue td
+  color: $ls-color-oil-blue !important
 
-.ls-color-warning
-  color: $color-warning !important
+.ls-color-success,
+.ls-table .ls-color-success td,
+.ls-color-green,
+.ls-table .ls-color-green td
+  color: $ls-color-green !important
+
+.ls-color-warning,
+.ls-table .ls-color-warning td,
+.ls-color-yellow,
+.ls-table .ls-color-yellow td
+  color: $ls-color-yellow !important
+
+.ls-color-purple,
+.ls-table .ls-color-purple td
+  color: $ls-color-purple !important
 
 .ls-dropdown-menu
   @extend .ls-color-white

--- a/source/assets/stylesheets/locastyle/base/_reset.sass
+++ b/source/assets/stylesheets/locastyle/base/_reset.sass
@@ -32,8 +32,7 @@ body
 a, a:hover
   text-decoration: none
 
-p a,
-a.ls-color-theme
+p a
   border-bottom-style: solid
   border-bottom-width: 1px
 

--- a/source/assets/stylesheets/locastyle/base/_variable-colors.scss
+++ b/source/assets/stylesheets/locastyle/base/_variable-colors.scss
@@ -84,3 +84,15 @@ $color-success: #388f39;
 $color-info:    #2881ac;
 $color-warning: #b9a016;
 $color-danger:  #d75553;
+
+//
+// Rebrand Colors
+//
+$ls-color-blue: #00acc8;
+$ls-color-gray: #e6e7e8;
+$ls-color-dark-gray: #58595b;
+$ls-color-oil-blue: #253746;
+$ls-color-green: #76bd22;
+$ls-color-purple: #9264cd;
+$ls-color-yellow: #f6b436;
+$ls-color-red: #d60037;

--- a/source/assets/stylesheets/locastyle/modules/_box.sass
+++ b/source/assets/stylesheets/locastyle/modules/_box.sass
@@ -64,7 +64,6 @@
     font-size: remtopx(1)
 
 .ls-ico-bg:before
-  @extend .ls-color-theme
   opacity: .1
   position: absolute
   top: -25%
@@ -123,4 +122,3 @@
 @media screen and (min-width: $screen-lg)
   .ls-box-filter .ls-label
     margin-bottom: 0
-

--- a/source/documentacao/css/classes-funcionais.html.erb
+++ b/source/documentacao/css/classes-funcionais.html.erb
@@ -226,8 +226,10 @@ type: css
     </tbody>
     </table>
 
-    <p>Backgrounds definidos com as cores padrões de tags e alertas:</p>
-    <table class="ls-table">
+    <p>Backgrounds definidos com as cores padrões de tags e alertas</p>
+
+    <h3 class="doc-title-5">Classes de background que serão descontinuadas na versão 5.0:</h3>
+    <table class="ls-table ls-no-margin-bottom">
       <thead>
         <tr>
           <th>Classe</th>
@@ -235,10 +237,6 @@ type: css
         </tr>
       </thead>
       <tbody>
-        <tr class="ls-background-primary">
-          <td><code>.ls-background-primary</code></td>
-          <td>Background do tema</td>
-        </tr>
         <tr class="ls-background-info">
           <td><code>.ls-background-info</code></td>
           <td>Background informativo</td>
@@ -254,6 +252,43 @@ type: css
         <tr class="ls-background-danger">
           <td><code>.ls-background-danger</code></td>
           <td>Background informando algum problema</td>
+        </tr>
+      </tbody>
+    </table>
+    <small><i>A classe <code>.ls-background-primary</code> foi descontinuada na versão 4.0.</i></small>
+
+    <h3 class="doc-title-5">Novas classes e cores de background:</h3>
+    <table class="ls-table">
+      <thead>
+        <tr>
+          <th>Classe</th>
+          <th>Descrição</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="ls-background-blue">
+          <td><code>.ls-background-blue</code></td>
+          <td>Background azul</td>
+        </tr>
+        <tr class="ls-background-oil-blue">
+          <td><code>.ls-background-oil-blue</code></td>
+          <td>Background azul petróleo</td>
+        </tr>
+        <tr class="ls-background-green">
+          <td><code>.ls-background-green</code></td>
+          <td>Background verde</td>
+        </tr>
+        <tr class="ls-background-yellow">
+          <td><code>.ls-background-yellow</code></td>
+          <td>Background amarelo</td>
+        </tr>
+        <tr class="ls-background-red">
+          <td><code>.ls-background-red</code></td>
+          <td>Background vermelho</td>
+        </tr>
+        <tr class="ls-background-purple">
+          <td><code>.ls-background-pruple</code></td>
+          <td>Background roxo</td>
         </tr>
       </tbody>
     </table>

--- a/source/documentacao/css/classes-funcionais.html.erb
+++ b/source/documentacao/css/classes-funcionais.html.erb
@@ -287,7 +287,7 @@ type: css
           <td>Background vermelho</td>
         </tr>
         <tr class="ls-background-purple">
-          <td><code>.ls-background-pruple</code></td>
+          <td><code>.ls-background-purple</code></td>
           <td>Background roxo</td>
         </tr>
       </tbody>

--- a/source/documentacao/css/classes-funcionais.html.erb
+++ b/source/documentacao/css/classes-funcionais.html.erb
@@ -318,23 +318,42 @@ type: css
   </table>
 
   <h2 class="doc-title-3">Cores</h2>
-  <p>
-    Classes que alteram cores de fundo e de texto:
-  </p>
-  <table class="ls-table">
+  <p>Classes que alteram cores de fundo e de texto:</p>
+
+  <h3 class="doc-title-5">Classes de cores que serão descontinuadas na versão 5.0:</h3>
+  <table class="ls-table ls-no-margin-bottom">
     <thead>
       <tr>
-        <th>Nome</th><th>Descrição</th>
+        <th>Nome</th>
+        <th>Descrição</th>
       </tr>
     </thead>
     <tbody>
-      <tr><td>.ls-bg-white</td><td>Insere background branco</td></tr>
-      <tr><td>.ls-color-black</td><td>Insere cor preta ao texto</td></tr>
-      <tr><td>.ls-color-danger</td><td>Insere cor de status danger</td></tr>
-      <tr><td>.ls-color-info</td><td>Insere cor de status info</td></tr>
-      <tr><td>.ls-color-success</td><td>Insere cor de status success</td></tr>
-      <tr><td>.ls-color-warning</td><td>Insere cor de status warning</td></tr>
-      <tr><td>.ls-color-theme</td><td>Insere a cor do tema</td></tr>
+      <tr class="ls-color-danger"><td>.ls-color-danger</td><td>Insere cor de status danger</td></tr>
+      <tr class="ls-color-info"><td>.ls-color-info</td><td>Insere cor de status info</td></tr>
+      <tr class="ls-color-success"><td>.ls-color-success</td><td>Insere cor de status success</td></tr>
+      <tr class="ls-color-warning"><td>.ls-color-warning</td><td>Insere cor de status warning</td></tr>
+    </tbody>
+  </table>
+  <small><i>A classe <code>.ls-color-theme</code> foi descontinuada na versão 4.0.</i></small>
+
+  <h3 class="doc-title-5">Novas classes de cores:</h3>
+  <table class="ls-table">
+    <thead>
+      <tr>
+        <th>Nome</th>
+        <th>Descrição</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="ls-background-oil-blue ls-color-white"><td>.ls-bg-white</td><td>Insere background branco</td></tr>
+      <tr class="ls-color-black"><td>.ls-color-black</td><td>Insere cor preta ao texto</td></tr>
+      <tr class="ls-color-red"><td>.ls-color-red</td><td>Insere a cor vermelha nos textos</td></tr>
+      <tr class="ls-color-blue"><td>.ls-color-blue</td><td>Insere a cor azul nos textos</td></tr>
+      <tr class="ls-color-oil-blue"><td>.ls-color-oil-blue</td><td>Insere a cor azul petróleo nos textos</td></tr>
+      <tr class="ls-color-green"><td>.ls-color-green</td><td>Insere a cor verde nos textos</td></tr>
+      <tr class="ls-color-yellow"><td>.ls-color-yellow</td><td>Insere a cor amarela nos textos</td></tr>
+      <tr class="ls-color-purple"><td>.ls-color-purple</td><td>Insere a cor roza nos textos</td></tr>
     </tbody>
   </table>
 

--- a/source/documentacao/exemplos/erro-404.html.erb
+++ b/source/documentacao/exemplos/erro-404.html.erb
@@ -55,7 +55,7 @@ title_product: Fake Product Name
         <p><strong>Você pode:</strong></p>
         <ol>
           <li>Verificar se digitou corretamente o endereço desejado.</li>
-          <li>Retornar à <a href="#" class="ls-color-theme">página inicial.</a></li>
+          <li>Retornar à <a href="#">página inicial.</a></li>
         </ol>
         <p>Se o problema persistir, entre em contato através de um dos <a href="#">canais de atendimento</a>.</p>
       </div>

--- a/source/documentacao/exemplos/erro-500.html.erb
+++ b/source/documentacao/exemplos/erro-500.html.erb
@@ -54,7 +54,7 @@ title_product: Fake Product Name
         <p><strong>Você pode:</strong></p>
         <ol>
           <li>Verificar se digitou corretamente o endereço desejado.</li>
-          <li>Retornar à <a href="#" class="ls-color-theme">página inicial.</a></li>
+          <li>Retornar à <a href="#">página inicial.</a></li>
         </ol>
         <p>Se o problema persistir, entre em contato através de um dos <a href="#">canais de atendimento</a>.</p>
       </div>

--- a/source/documentacao/exemplos/painel1/base.html.erb
+++ b/source/documentacao/exemplos/painel1/base.html.erb
@@ -53,7 +53,7 @@ title_product: Revenda do Email Marketing
       <div class="ls-box">
         <h6 class="ls-title-4 color-default">Disponível</h6>
         <span class="ls-board-data">
-          <strong class="ls-color-theme">81%</strong>
+          <strong>81%</strong>
           989.257
         </span>
       </div>
@@ -63,7 +63,7 @@ title_product: Revenda do Email Marketing
 </div>
 
 <div class="ls-box ls-lg-space ls-ico-user-add ls-ico-bg">
-  <h1 class="ls-title-1 ls-color-theme">Cadastre contatos na sua revenda</h1>
+  <h1 class="ls-title-1">Cadastre contatos na sua revenda</h1>
   <p>Comece agora: cadastre seu primeiro cliente, adicione envios e acompanhe o seu desenvolvimento.</p>
   <%= link_to 'Cadastrar meu primeiro cliente', 'new-client', :class => 'ls-btn-primary' %>
 </div>

--- a/source/documentacao/exemplos/painel1/home.html.erb
+++ b/source/documentacao/exemplos/painel1/home.html.erb
@@ -68,7 +68,7 @@ title_product: Revenda do Email Marketing
         </div>
         <div class="ls-box-body">
           <span class="ls-board-data">
-            <strong class="ls-color-theme">81%</strong>
+            <strong>81%</strong>
             <small>989.257</small>
           </span>
         </div>

--- a/source/documentacao/exemplos/painel2/bounces.html.erb
+++ b/source/documentacao/exemplos/painel2/bounces.html.erb
@@ -135,7 +135,7 @@ title_product: SMTP Locaweb
           <tbody>
             <%- 5.times do |num| %>
               <tr>
-                <td class="hidden-xs ls-color-theme"><a href="#">Soft Bounce</a></td>
+                <td class="hidden-xs"><a href="#">Soft Bounce</a></td>
                 <td class="hidden-xs">21/09/2013 as 20:00 PM</td>
                 <td><%= lorem.email %></td>
                 <td><%= lorem.email %></td>

--- a/source/documentacao/exemplos/painel2/complaints.html.erb
+++ b/source/documentacao/exemplos/painel2/complaints.html.erb
@@ -41,7 +41,7 @@ title_product: SMTP Locaweb
         </div>
         <div class="ls-box-body">
           <div class="col-lg-offset-3 col-lg-3 col-xs-6">
-            <strong class="ls-color-theme" data-prefix="%">0,60</strong>
+            <strong data-prefix="%">0,60</strong>
             <small>ideal</small>
           </div>
           <div class="col-lg-3 col-xs-6">
@@ -122,7 +122,7 @@ title_product: SMTP Locaweb
           <tbody>
             <%- 5.times do |num| %>
               <tr>
-                <td class="hidden-xs ls-color-theme"><a href="#">Soft Bounce</a></td>
+                <td class="hidden-xs"><a href="#">Soft Bounce</a></td>
                 <td class="hidden-xs">21/09/2013 as 20:00 PM</td>
                 <td><%= lorem.email %></td>
                 <td><%= lorem.email %></td>

--- a/source/documentacao/exemplos/painel2/home.html.erb
+++ b/source/documentacao/exemplos/painel2/home.html.erb
@@ -165,7 +165,7 @@ title_product: SMTP Locaweb
         </div>
         <div class="ls-box-body">
           <span class="ls-board-data">
-            <strong class="ls-color-theme">81%</strong>
+            <strong>81%</strong>
           </span>
         </div>
       </div>

--- a/source/documentacao/exemplos/painel2/openings.html.erb
+++ b/source/documentacao/exemplos/painel2/openings.html.erb
@@ -138,7 +138,7 @@ title_product: SMTP Locaweb
           <tbody>
             <%- 5.times do |num| %>
               <tr>
-                <td class="hidden-xs ls-color-theme"><a href="#">Soft Bounce</a></td>
+                <td class="hidden-xs"><a href="#">Soft Bounce</a></td>
                 <td class="hidden-xs">21/09/2013 as 20:00 PM</td>
                 <td><%= lorem.email %></td>
                 <td><%= lorem.email %></td>

--- a/source/documentacao/exemplos/painel2/reputation-terms.html.erb
+++ b/source/documentacao/exemplos/painel2/reputation-terms.html.erb
@@ -13,7 +13,7 @@ title_product: SMTP Locaweb
   Para que você utilize o seu serviço SMTP da melhor maneira, é muito importante que conheça as regras que entrarão em vigor a partir do dia <strong>XX/XX/XXXX.</strong>
 </p>
 
-<h2 class="ls-title-3 ls-color-theme"><strong>Reputação</strong></h2>
+<h2 class="ls-title-3"><strong>Reputação</strong></h2>
 <p>
   A reputação é composta pelos envios entregues com sucesso, <strong>hard bounces</strong> e e-mails denunciados como <strong>spam.</strong> <br>
   Veja como funciona:

--- a/source/documentacao/exemplos/painel2/reputation.html.erb
+++ b/source/documentacao/exemplos/painel2/reputation.html.erb
@@ -116,7 +116,7 @@ title_product: SMTP Locaweb
           <tbody>
             <%- 5.times do |num| %>
               <tr>
-                <td class="hidden-xs ls-color-theme"><a href="#">Soft Bounce</a></td>
+                <td class="hidden-xs"><a href="#">Soft Bounce</a></td>
                 <td class="hidden-xs">21/09/2013 as 20:00 PM</td>
                 <td><%= lorem.email %></td>
                 <td><%= lorem.email %></td>

--- a/source/documentacao/exemplos/painel2/resume.html.erb
+++ b/source/documentacao/exemplos/painel2/resume.html.erb
@@ -45,7 +45,7 @@ title_product: SMTP Locaweb
             </div>
           </div>
           <div class="ls-half-board-data">
-            <strong class="ls-color-theme">20.000</strong>
+            <strong>20.000</strong>
             <small>entregues</small>
             <strong class="ls-color-danger">5.000</strong>
             <small>bounces</small>
@@ -96,7 +96,7 @@ title_product: SMTP Locaweb
           <button type="button" data-ls-module="tabs" data-target=".child2" class="ls-btn ls-ico-table-alt"></button>
           <button type="button" class="ls-btn-primary ls-no-margin-top" data-ls-module="tabs" data-target="#infoAll">Detalhar</button>
         </div>
-        
+
       </div>
     </div>
 
@@ -143,7 +143,7 @@ title_product: SMTP Locaweb
           <tbody>
             <%- 5.times do |num| %>
               <tr>
-                <td class="hidden-xs ls-color-theme"><a href="#">Soft Bounce</a></td>
+                <td class="hidden-xs"><a href="#">Soft Bounce</a></td>
                 <td class="hidden-xs">21/09/2013 as 20:00 PM</td>
                 <td><%= lorem.email %></td>
                 <td><%= lorem.email %></td>

--- a/source/documentacao/exemplos/painel3/pre-painel.html.erb
+++ b/source/documentacao/exemplos/painel3/pre-painel.html.erb
@@ -98,7 +98,7 @@ topbar_gray: true
       </div>
       <div class="col-xs-12 col-md-4">
         <strong class="ls-list-label">Data de expiração</strong>
-        30/12/2014 | <a href="" class="ls-color-theme">Renovar domínio</a>
+        30/12/2014 | <a href="">Renovar domínio</a>
       </div>
       <div class="col-xs-12 col-md-4">
         <strong class="ls-list-label">Status</strong>

--- a/source/documentacao/exemplos/painel4/home-first-access.html.erb
+++ b/source/documentacao/exemplos/painel4/home-first-access.html.erb
@@ -10,7 +10,7 @@ title_product: Criador de Sites 2.0
 <h1 class="ls-title-intro ls-ico-home">Página inicial</h1>
 
 <div class="ls-box ls-lg-space ls-ico-code ls-ico-bg">
-  <h1 class="ls-title-1 ls-color-theme">Criar meu site</h1>
+  <h1 class="ls-title-1">Criar meu site</h1>
   <p>Edite a aparência, as páginas e todo o conteúdo do seu site.</p>
   <a class="ls-btn-primary" href="#">Comece agora</a>
 </div>
@@ -78,7 +78,7 @@ title_product: Criador de Sites 2.0
         </div>
         <div class="ls-box-body">
           <span class="ls-board-data">
-            <strong class="ls-color-theme">1</strong>
+            <strong>1</strong>
           </span>
         </div>
       </div>

--- a/source/documentacao/exemplos/painel5/dns-entries.html.erb
+++ b/source/documentacao/exemplos/painel5/dns-entries.html.erb
@@ -42,7 +42,7 @@ panel: painel5
       <div class="ls-box">
         <h6 class="ls-title-4 color-default">Zona de Dns</h6>
         <span class="ls-board-data">
-          <strong class="ls-color-theme">COM AUTORIDADE<small>NA LOCAWEB</small></strong>
+          <strong>COM AUTORIDADE<small>NA LOCAWEB</small></strong>
         </span>
       </div>
     </div>

--- a/source/documentacao/exemplos/painel5/home.html.erb
+++ b/source/documentacao/exemplos/painel5/home.html.erb
@@ -52,7 +52,7 @@ panel: painel5
         </div>
         <div class="ls-box-body">
           <span class="ls-board-data">
-            <strong class="ls-color-theme">COM AUTORIDADE<small>NA LOCAWEB</small></strong>
+            <strong>COM AUTORIDADE<small>NA LOCAWEB</small></strong>
           </span>
         </div>
       </div>

--- a/source/documentacao/exemplos/product-not-hired.html.erb
+++ b/source/documentacao/exemplos/product-not-hired.html.erb
@@ -52,7 +52,7 @@ title_product: Fake Product Name
 
         <ol>
           <li>Verificar se digitou corretamente o endereço desejado.</li>
-          <li>Retornar à <a href="#" class="ls-color-theme">página inicial.</a></li>
+          <li>Retornar à <a href="#">página inicial.</a></li>
         </ol>
         <p>Se o problema persistir, entre em contato através de um dos <a href="#">canais de atendimento</a>.</p>
       </div>

--- a/source/documentacao/introducao/index.html.erb
+++ b/source/documentacao/introducao/index.html.erb
@@ -89,12 +89,12 @@ description: Iniciando seu desenvolvimento com Locaweb Style
   <p>Se você quiser fuçar no código ou contribuir esse é o melhor caminho. Nosso código está totalmente disponível no <a href="http://github.com/">GitHub</a> e você pode fazer o download desse código pelos meios abaixo:</p>
   <div class="row">
     <div class="col-md-6">
-      <h4><a href="http://github.com/locaweb/locawebstyle" class="ls-color-theme">Clone ou Fork pelo GitHub</a></h4>
+      <h4><a href="http://github.com/locaweb/locawebstyle">Clone ou Fork pelo GitHub</a></h4>
       <p>Faça um fork no GitHub e contribua.</p>
       <a href="https://github.com/locaweb/locawebstyle" class="ls-btn">Ir para GitHub</a>
     </div>
     <div class="col-md-6">
-      <h4><a href="https://github.com/locaweb/locawebstyle/archive/master.zip" class="ls-color-theme">Baixe o repositório <strong>master</strong></a></h4>
+      <h4><a href="https://github.com/locaweb/locawebstyle/archive/master.zip">Baixe o repositório <strong>master</strong></a></h4>
       <p>Baixe branch master direto do GitHub.</p>
       <a href="https://github.com/locaweb/locawebstyle/archive/master.zip" class="ls-btn">Baixar</a>
     </div>

--- a/source/documentacao/introducao/suporte-browsers.html.erb
+++ b/source/documentacao/introducao/suporte-browsers.html.erb
@@ -10,10 +10,10 @@ description: Entenda como melhorar o suporte a browsers antigos, como o IE8
   <p>O Locaweb Style dá suporte a todos os navegadores atuais. Nós <strong>consideramos atuais duas versões anteriores dos browsers</strong>: se o atual é o IE 11, nós damos suporte a partir do IE 9. Já nos antigos, esse suporte está no formato Progressive Enhancement, sendo que os componentes e o layout funcionam na experiência máxima que o browser suporta.</p>
   <p>Para dar suporte ao Internet Explorer 8, é necessário implementar algumas modificações:</p>
   <ol>
-    <li><a href="http://jquery.com/download/" target="_blank" class="ls-color-theme">jQuery</a> com suporte a navegadores antigos. Nesse caso, você precisa usar a jQuery na versão 1.11 ou menor. As versões mais novas, da 2.0 ou superior, não suportam browsers antigos.</li>
-    <li><a href="https://code.google.com/p/html5shim/" target="_blank" class="ls-color-theme">html5shiv</a>. Esse plugin JavaScript faz os browsers antigos conhecerem as tags do HTML5.</li>
-    <li><a href="https://code.google.com/p/css3-mediaqueries-js/" target="_blank" class="ls-color-theme">mediaqueries</a>. Faz browsers antigos suportarem as mediaqueries do CSS.</li>
-    <li><a href="http://selectivizr.com/" target="_blank" class="ls-color-theme">Selectivizr</a> para os browsers entenderem os novos seletores do CSS3.</li>
+    <li><a href="http://jquery.com/download/" target="_blank">jQuery</a> com suporte a navegadores antigos. Nesse caso, você precisa usar a jQuery na versão 1.11 ou menor. As versões mais novas, da 2.0 ou superior, não suportam browsers antigos.</li>
+    <li><a href="https://code.google.com/p/html5shim/" target="_blank">html5shiv</a>. Esse plugin JavaScript faz os browsers antigos conhecerem as tags do HTML5.</li>
+    <li><a href="https://code.google.com/p/css3-mediaqueries-js/" target="_blank">mediaqueries</a>. Faz browsers antigos suportarem as mediaqueries do CSS.</li>
+    <li><a href="http://selectivizr.com/" target="_blank">Selectivizr</a> para os browsers entenderem os novos seletores do CSS3.</li>
   </ol>
 
   <p>Abaixo um exemplo usando as tags condicionais da Microsoft. Nós tentamos sempre usar os princícios do Progressive Enhancement para que os browsers antigos tenham a melhor experiência possível.</p>

--- a/source/documentacao/praticas/javascript.html.erb
+++ b/source/documentacao/praticas/javascript.html.erb
@@ -29,8 +29,8 @@ description: Se quiser contribuir com JavaScript, siga essas práticas
   <p><strong>Identação:</strong> utilizamos 2 espaços, mas o mais importante é seguir um estilo único. Nunca misture espaços e tabs em único arquivo. Para facilitar incluímos no projeto um arquivo de configuraçao de editores, o ".editorconfig", saiba mais sobre ele em <a href="http://editorconfig.org/" target="_blank">editorconfig.org</a> </p>
   <p>Existem plugins para vários editores, no nosso time usamos:</p>
   <ul>
-    <li><a href="https://github.com/sindresorhus/editorconfig-sublime#readme" target="_blank" class="ls-color-theme">Plugin para Sublime Text</a></li>
-    <li><a href="https://github.com/editorconfig/editorconfig-vim#readme" target="_blank" class="ls-color-theme">Plugin para Vim</a></li>
+    <li><a href="https://github.com/sindresorhus/editorconfig-sublime#readme" target="_blank">Plugin para Sublime Text</a></li>
+    <li><a href="https://github.com/editorconfig/editorconfig-vim#readme" target="_blank">Plugin para Vim</a></li>
   </ul>
 
   <p><strong>Sintaxe:</strong> para separaçao dos blocos de código, utilizamos o estilo1TBS, por exemplo:</p>

--- a/source/documentacao/shared/_password-inline.erb
+++ b/source/documentacao/shared/_password-inline.erb
@@ -15,7 +15,7 @@
     <label class="ls-label">
       <b class="ls-label-text ls-hidden-accessible">Senha (com texto)</b>
       <input type="password" maxlength="20" id="password_field3a" name="password" value="locastyle é da hora né?" >
-      <a class="ls-toggle-pass ls-color-theme" data-target="#password_field3a" href="#">Alterar</a>
+      <a class="ls-toggle-pass" data-target="#password_field3a" href="#">Alterar</a>
     </label>
   </fieldset>
 </form>

--- a/source/documentacao/shared/_password.erb
+++ b/source/documentacao/shared/_password.erb
@@ -15,7 +15,7 @@
     <label class="ls-label">
       <b class="ls-label-text ls-hidden-accessible">Senha (com texto)</b>
       <input type="password" maxlength="20" id="password_field3" name="password" value="locastyle é da hora né?" >
-      <a class="ls-toggle-pass ls-color-theme" data-target="#password_field3" href="#">Alterar</a>
+      <a class="ls-toggle-pass" data-target="#password_field3" href="#">Alterar</a>
     </label>
   </fieldset>
 </form>

--- a/source/documentacao/shared/box-info/_box-info-complex.erb
+++ b/source/documentacao/shared/box-info/_box-info-complex.erb
@@ -13,7 +13,7 @@
         </div>
         <div class="ls-box-body">
           <div class="col-lg-offset-3 col-lg-3 col-xs-6">
-            <strong class="ls-color-theme" data-prefix="%">0,60</strong>
+            <strong data-prefix="%">0,60</strong>
             <small>ideal</small>
           </div>
           <div class="col-lg-3 col-xs-6">

--- a/source/documentacao/shared/box/_box-bg-icon.erb
+++ b/source/documentacao/shared/box/_box-bg-icon.erb
@@ -1,5 +1,5 @@
 <div class="ls-box ls-lg-space ls-ico-user-add ls-ico-bg">
-  <h1 class="ls-title-1 ls-color-theme">Cadastre contatos na sua revenda</h1>
+  <h1 class="ls-title-1">Cadastre contatos na sua revenda</h1>
   <p>Comece agora: cadastre seu primeiro cliente, adicione envios e acompanhe o seu desenvolvimento.</p>
   <%= link_to 'Cadastrar meu primeiro cliente', '#', :class => 'ls-btn-primary' %>
 </div>

--- a/source/documentacao/shared/box/_box-grid.erb
+++ b/source/documentacao/shared/box/_box-grid.erb
@@ -31,7 +31,7 @@
     <div class="col-sm-6 col-md-3">
       <div class="ls-box">
         <h6 class="ls-title-4 color-default">DISPONÍVEL</h6>
-          <strong class="ls-color-theme">90%</strong>
+          <strong>90%</strong>
           <small>90.000</small>
       </div>
     </div>


### PR DESCRIPTION
Rebrand das classes funcionais de cores de textos e backgrounds.
As classes `ls-background-primary` e `ls-color-theme` foram descontinuadas na versão 4.0 do Locastyle. As demais classes (success, warning, danger e info) deverão ser descontinuadas na versão 5.0.

Também foram adicionadas as novas cores principais do rebrand, para auxiliar no desenvolvimento das demais issues.

closes #1816 